### PR TITLE
Extract auth content from security 1.x into security-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Authentication security for Laravel: two-factor authentication (email/TOTP), pas
 
 This package is part of the **ArtisanPack UI Security 2.0** split — the auth-focused features previously bundled inside `artisanpack-ui/security` (1.x) live here in 2.0+.
 
-> **Status:** scaffold. Content is being extracted from `artisanpack-ui/security` 1.x in follow-up PRs. See the package roadmap on the issue tracker.
+> **Status:** initial extraction. Source files are migrated from `artisanpack-ui/security` 1.x. Comprehensive test coverage migration is a follow-up — see open issues.
 
 ## Installation
 

--- a/config/artisanpack/security-auth.php
+++ b/config/artisanpack/security-auth.php
@@ -1,0 +1,167 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\SecurityAuth\TwoFactor\Providers\EmailProvider;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Two-factor authentication
+    |--------------------------------------------------------------------------
+    */
+
+    'two_factor' => [
+        'default'   => env( 'TWO_FACTOR_PROVIDER', 'email' ),
+        'providers' => [
+            'email' => [
+                'driver' => EmailProvider::class,
+            ],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Routes
+    |--------------------------------------------------------------------------
+    |
+    | Named routes that the package needs to redirect to. Override these to
+    | point at your application's own routes when you've published custom
+    | challenge / verification screens.
+    |
+    */
+
+    'routes' => [
+        'verify' => 'two-factor.challenge',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password security
+    |--------------------------------------------------------------------------
+    */
+
+    'passwordSecurity' => [
+        'enabled' => env( 'SECURITY_AUTH_PASSWORD_ENABLED', true ),
+
+        'complexity' => [
+            'minLength'                   => 8,
+            'maxLength'                   => 128,
+            'requireUppercase'            => true,
+            'requireLowercase'            => true,
+            'requireNumbers'              => true,
+            'requireSymbols'              => true,
+            'minUniqueCharacters'         => 4,
+            'disallowRepeatingCharacters' => 3,
+            'disallowSequentialCharacters' => 3,
+            'disallowCommonPasswords'     => true,
+            'disallowUserAttributes'      => true,
+        ],
+
+        'history' => [
+            'enabled'               => true,
+            'count'                 => 5,
+            'minDaysBetweenChanges' => 1,
+        ],
+
+        'expiration' => [
+            'enabled'      => false,
+            'days'         => 90,
+            'warningDays'  => 14,
+            'graceLogins'  => 3,
+            'exemptRoles'  => [],
+        ],
+
+        'breachChecking' => [
+            'enabled'          => env( 'SECURITY_AUTH_BREACH_CHECK_ENABLED', true ),
+            'onRegistration'   => true,
+            'onPasswordChange' => true,
+            'onLogin'          => false,
+            'blockCompromised' => true,
+            'apiTimeout'       => 5,
+            'cacheResults'     => true,
+            'cacheTtl'         => 86400,
+        ],
+
+        'strengthMeter' => [
+            'enabled'       => true,
+            'showFeedback'  => true,
+            'minScore'      => 3,
+            'showCrackTime' => true,
+        ],
+
+        'logging' => [
+            'passwordChanges'      => true,
+            'failedValidations'    => true,
+            'breachDetections'     => true,
+            'expirationWarnings'   => true,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Account lockout
+    |--------------------------------------------------------------------------
+    */
+
+    'account_lockout' => [
+        'enabled'           => env( 'SECURITY_AUTH_LOCKOUT_ENABLED', true ),
+        'soft_lockout'      => true,
+        'permanent_lockout' => false,
+        'whitelist'         => [],
+
+        'triggers' => [
+            'failed_login'       => true,
+            'suspicious_activity' => true,
+            'manual'              => true,
+        ],
+
+        'lockout_duration' => [
+            'initial_minutes' => 5,
+            'progressive'     => true,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Advanced session management
+    |--------------------------------------------------------------------------
+    */
+
+    'advanced_sessions' => [
+        'binding' => [
+            'ip_address' => true,
+            'user_agent' => true,
+        ],
+
+        'rotation' => [
+            'enabled'          => true,
+            'interval_minutes' => 30,
+        ],
+
+        'timeouts' => [
+            'idle_minutes'         => 30,
+            'absolute_minutes'     => 480,
+            'idle_warning_minutes' => 25,
+        ],
+
+        'concurrent_sessions' => [
+            'enabled'      => true,
+            'max_sessions' => 5,
+            'strategy'     => 'oldest',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Step-up authentication
+    |--------------------------------------------------------------------------
+    */
+
+    'step_up_authentication' => [
+        'timeout_minutes' => 15,
+        'routes'          => [],
+    ],
+
+];

--- a/database/migrations/2025_09_28_205614_add_two_factor_to_users_table.php
+++ b/database/migrations/2025_09_28_205614_add_two_factor_to_users_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up(): void
+	{
+		Schema::table( 'users', function ( Blueprint $table ) {
+			$table->text( 'two_factor_secret' )
+				  ->after( 'password' )
+				  ->nullable();
+
+			$table->text( 'two_factor_recovery_codes' )
+				  ->after( 'two_factor_secret' )
+				  ->nullable();
+
+			$table->timestamp( 'two_factor_enabled_at' )
+				  ->after( 'two_factor_recovery_codes' )
+				  ->nullable();
+		} );
+	}
+
+	public function down(): void
+	{
+		Schema::table( 'users', function ( Blueprint $table ) {
+			$table->dropColumn( [ 'two_factor_secret', 'two_factor_recovery_codes', 'two_factor_enabled_at' ] );
+		} );
+	}
+};

--- a/database/migrations/authentication/2025_12_24_000007_create_user_sessions_table.php
+++ b/database/migrations/authentication/2025_12_24_000007_create_user_sessions_table.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('user_sessions', function (Blueprint $table) {
+            $table->string('id', 255)->primary();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('device_id')->nullable()->constrained('user_devices')->nullOnDelete();
+            $table->string('ip_address', 45);
+            $table->text('user_agent')->nullable();
+            $table->json('location')->nullable();
+            $table->text('payload')->nullable();
+            $table->enum('auth_method', ['password', 'social', 'sso', 'webauthn', 'biometric', '2fa'])->default('password');
+            $table->boolean('is_current')->default(false);
+            $table->timestamp('last_activity_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamp('created_at')->nullable();
+
+            $table->index('user_id', 'idx_user_sessions');
+            $table->index('expires_at', 'idx_user_sessions_expires');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('user_sessions');
+    }
+};

--- a/database/migrations/authentication/2025_12_24_000007_create_user_sessions_table.php
+++ b/database/migrations/authentication/2025_12_24_000007_create_user_sessions_table.php
@@ -37,6 +37,7 @@ return new class extends Migration
             $table->boolean('is_current')->default(false);
             $table->timestamp('last_activity_at')->nullable();
             $table->timestamp('expires_at')->nullable();
+            $table->timestamp('terminated_at')->nullable();
             $table->timestamp('created_at')->nullable();
 
             $table->index('user_id', 'idx_user_sessions');

--- a/database/migrations/authentication/2025_12_24_000007_create_user_sessions_table.php
+++ b/database/migrations/authentication/2025_12_24_000007_create_user_sessions_table.php
@@ -13,10 +13,22 @@ return new class extends Migration
      */
     public function up(): void
     {
+        if (Schema::hasTable('user_sessions')) {
+            return;
+        }
+
         Schema::create('user_sessions', function (Blueprint $table) {
             $table->string('id', 255)->primary();
-            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
-            $table->foreignId('device_id')->nullable()->constrained('user_devices')->nullOnDelete();
+            // user_id is constrained against the host app's users table when present;
+            // skip the FK if `users` doesn't exist yet (e.g. testbench :memory: setup).
+            if (Schema::hasTable('users')) {
+                $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            } else {
+                $table->unsignedBigInteger('user_id');
+            }
+            // device_id stays nullable + un-constrained here; user_devices lives in
+            // security-advanced-auth and is only present when that package is installed.
+            $table->unsignedBigInteger('device_id')->nullable();
             $table->string('ip_address', 45);
             $table->text('user_agent')->nullable();
             $table->json('location')->nullable();

--- a/database/migrations/authentication/2025_12_24_000009_create_account_lockouts_table.php
+++ b/database/migrations/authentication/2025_12_24_000009_create_account_lockouts_table.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('account_lockouts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->string('ip_address', 45)->nullable();
+            $table->enum('lockout_type', ['temporary', 'permanent', 'soft'])->default('temporary');
+            $table->string('reason', 255);
+            $table->unsignedInteger('failed_attempts')->default(0);
+            $table->timestamp('locked_at');
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamp('unlocked_at')->nullable();
+            $table->foreignId('unlocked_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('unlock_reason', 255)->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'unlocked_at'], 'idx_user_active');
+            $table->index(['ip_address', 'unlocked_at'], 'idx_ip_active');
+            $table->index('expires_at', 'idx_account_lockouts_expires');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('account_lockouts');
+    }
+};

--- a/database/migrations/password/2025_12_23_000001_create_password_history_table.php
+++ b/database/migrations/password/2025_12_23_000001_create_password_history_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('password_history')) {
+            Schema::create('password_history', function (Blueprint $table): void {
+                $table->id();
+                $table->unsignedBigInteger('user_id')->index();
+                $table->string('password_hash');
+                $table->timestamp('created_at')->index();
+
+                $table->foreign('user_id')
+                    ->references('id')
+                    ->on('users')
+                    ->onDelete('cascade');
+
+                // Composite index for efficient history lookups
+                $table->index(['user_id', 'created_at']);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('password_history');
+    }
+};

--- a/database/migrations/password/2025_12_23_000001_create_password_history_table.php
+++ b/database/migrations/password/2025_12_23_000001_create_password_history_table.php
@@ -10,20 +10,28 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (! Schema::hasTable('password_history')) {
-            Schema::create('password_history', function (Blueprint $table): void {
-                $table->id();
-                $table->unsignedBigInteger('user_id')->index();
-                $table->string('password_hash');
-                $table->timestamp('created_at')->index();
+        if (Schema::hasTable('password_history')) {
+            return;
+        }
 
+        Schema::create('password_history', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('user_id')->index();
+            $table->string('password_hash');
+            $table->timestamp('created_at')->index();
+
+            // Composite index for efficient history lookups
+            $table->index(['user_id', 'created_at']);
+        });
+
+        // Add the FK in a separate step so the migration doesn't fail when
+        // the host app's users table isn't present yet.
+        if (Schema::hasTable('users')) {
+            Schema::table('password_history', function (Blueprint $table): void {
                 $table->foreign('user_id')
                     ->references('id')
                     ->on('users')
                     ->onDelete('cascade');
-
-                // Composite index for efficient history lookups
-                $table->index(['user_id', 'created_at']);
             });
         }
     }

--- a/database/migrations/password/2025_12_23_000002_add_password_security_columns_to_users_table.php
+++ b/database/migrations/password/2025_12_23_000002_add_password_security_columns_to_users_table.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Add password security columns to users table.
+ *
+ * Note: This migration only runs if the `users` table exists. Applications
+ * without a standard users table can skip this migration or customize it
+ * for their user model's table.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Only modify users table if it exists
+        if (! Schema::hasTable('users')) {
+            return;
+        }
+
+        Schema::table('users', function (Blueprint $table): void {
+            if (! Schema::hasColumn('users', 'password_changed_at')) {
+                $table->timestamp('password_changed_at')
+                    ->nullable()
+                    ->after('password');
+            }
+
+            if (! Schema::hasColumn('users', 'password_expires_at')) {
+                $table->timestamp('password_expires_at')
+                    ->nullable()
+                    ->after('password_changed_at');
+            }
+
+            if (! Schema::hasColumn('users', 'force_password_change')) {
+                $table->boolean('force_password_change')
+                    ->default(false)
+                    ->after('password_expires_at');
+            }
+
+            if (! Schema::hasColumn('users', 'grace_logins_remaining')) {
+                $table->unsignedTinyInteger('grace_logins_remaining')
+                    ->nullable()
+                    ->after('force_password_change');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('users')) {
+            return;
+        }
+
+        Schema::table('users', function (Blueprint $table): void {
+            $columns = ['password_changed_at', 'password_expires_at', 'force_password_change', 'grace_logins_remaining'];
+
+            foreach ($columns as $column) {
+                if (Schema::hasColumn('users', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+    }
+};

--- a/resources/views/emails/two-factor-code.blade.php
+++ b/resources/views/emails/two-factor-code.blade.php
@@ -1,0 +1,14 @@
+<x-mail::message>
+# Your Two-Factor Authentication Code
+
+Use the code below to finish signing in. The code expires in 10 minutes.
+
+<x-mail::panel>
+{{ $code }}
+</x-mail::panel>
+
+If you didn't try to sign in, you can safely ignore this email.
+
+Thanks,<br>
+{{ config('app.name') }}
+</x-mail::message>

--- a/src/Authentication/Contracts/AccountLockoutInterface.php
+++ b/src/Authentication/Contracts/AccountLockoutInterface.php
@@ -1,0 +1,99 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Authentication\Contracts;
+
+use ArtisanPackUI\SecurityAuth\Models\AccountLockout;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+interface AccountLockoutInterface
+{
+    /**
+     * Check if a user account is locked.
+     */
+    public function isUserLocked( Authenticatable $user ): bool;
+
+    /**
+     * Check if an IP address is locked.
+     */
+    public function isIpLocked( string $ipAddress ): bool;
+
+    /**
+     * Get the active lockout for a user.
+     */
+    public function getUserLockout( Authenticatable $user ): ?AccountLockout;
+
+    /**
+     * Get the active lockout for an IP.
+     */
+    public function getIpLockout( string $ipAddress ): ?AccountLockout;
+
+    /**
+     * Record a failed authentication attempt.
+     *
+     * @return array{locked: bool, lockout: ?AccountLockout, attempts_remaining: int}
+     */
+    public function recordFailedAttempt( string $trigger, ?Authenticatable $user = null, ?string $ipAddress = null ): array;
+
+    /**
+     * Clear failed attempts on successful authentication.
+     */
+    public function clearFailedAttempts( ?Authenticatable $user = null, ?string $ipAddress = null ): void;
+
+    /**
+     * Lock a user account.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    public function lockUser( Authenticatable $user, string $reason, string $lockoutType = 'temporary', ?int $durationMinutes = null, array $metadata = [] ): AccountLockout;
+
+    /**
+     * Lock an IP address.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    public function lockIp( string $ipAddress, int $durationMinutes, string $reason, string $lockoutType = 'temporary', array $metadata = [] ): AccountLockout;
+
+    /**
+     * Unlock a user account.
+     */
+    public function unlockUser( Authenticatable $user, ?Authenticatable $unlockedBy = null, ?string $reason = null ): bool;
+
+    /**
+     * Unlock an IP address.
+     */
+    public function unlockIp( string $ipAddress, ?Authenticatable $unlockedBy = null, ?string $reason = null ): bool;
+
+    /**
+     * Get the remaining lockout duration in seconds.
+     */
+    public function getRemainingLockoutDuration( AccountLockout $lockout ): int;
+
+    /**
+     * Calculate progressive lockout duration based on lockout count.
+     */
+    public function calculateProgressiveDuration( int $lockoutCount ): int;
+
+    /**
+     * Check if user should be permanently locked.
+     */
+    public function shouldPermanentlyLock( Authenticatable $user ): bool;
+
+    /**
+     * Get lockout history for a user.
+     *
+     * @return \Illuminate\Support\Collection<int, AccountLockout>
+     */
+    public function getLockoutHistory( Authenticatable $user ): \Illuminate\Support\Collection;
+
+    /**
+     * Process automatic unlock of expired lockouts.
+     */
+    public function processExpiredLockouts(): int;
+
+    /**
+     * Check if an entity is whitelisted.
+     */
+    public function isWhitelisted( ?Authenticatable $user = null, ?string $ipAddress = null): bool;
+}

--- a/src/Authentication/Contracts/SessionSecurityInterface.php
+++ b/src/Authentication/Contracts/SessionSecurityInterface.php
@@ -1,0 +1,88 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Authentication\Contracts;
+
+use ArtisanPackUI\SecurityAuth\Models\UserSession;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\Request;
+
+interface SessionSecurityInterface
+{
+    /**
+     * Create a new secure session for the user.
+     *
+     * @param  array<string, mixed>  $metadata
+     */
+    public function createSession( Authenticatable $user, Request $request, string $authMethod, array $metadata = [] ): UserSession;
+
+    /**
+     * Validate session bindings (IP, user agent, device).
+     *
+     * @return array{valid: bool, violations: array<string>}
+     */
+    public function validateSessionBindings( UserSession $session, Request $request ): array;
+
+    /**
+     * Update session activity timestamp.
+     */
+    public function touchSession( UserSession $session ): void;
+
+    /**
+     * Rotate the session ID for security.
+     */
+    public function rotateSession( UserSession $session ): UserSession;
+
+    /**
+     * Terminate a specific session.
+     */
+    public function terminateSession( string $sessionId ): bool;
+
+    /**
+     * Terminate all sessions for a user except the current one.
+     */
+    public function terminateOtherSessions( Authenticatable $user, string $currentSessionId ): int;
+
+    /**
+     * Terminate all sessions for a user.
+     */
+    public function terminateAllSessions( Authenticatable $user ): int;
+
+    /**
+     * Get all active sessions for a user.
+     *
+     * @return \Illuminate\Support\Collection<int, UserSession>
+     */
+    public function getUserSessions( Authenticatable $user ): \Illuminate\Support\Collection;
+
+    /**
+     * Get the current session for the request.
+     */
+    public function getCurrentSession( Request $request ): ?UserSession;
+
+    /**
+     * Check if concurrent session limit is exceeded.
+     */
+    public function isSessionLimitExceeded( Authenticatable $user ): bool;
+
+    /**
+     * Enforce concurrent session limit (terminate oldest if needed).
+     */
+    public function enforceSessionLimit( Authenticatable $user ): int;
+
+    /**
+     * Check if session is expired (idle or absolute timeout).
+     */
+    public function isSessionExpired( UserSession $session ): bool;
+
+    /**
+     * Check if session is approaching idle timeout.
+     */
+    public function isApproachingIdleTimeout( UserSession $session ): bool;
+
+    /**
+     * Prune expired sessions from database.
+     */
+    public function pruneExpiredSessions(): int;
+}

--- a/src/Authentication/Lockout/AccountLockoutManager.php
+++ b/src/Authentication/Lockout/AccountLockoutManager.php
@@ -1,0 +1,399 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Authentication\Lockout;
+
+use ArtisanPackUI\SecurityAuth\Authentication\Contracts\AccountLockoutInterface;
+use ArtisanPackUI\SecurityAuth\Events\AccountLocked;
+use ArtisanPackUI\SecurityAuth\Models\AccountLockout;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+
+class AccountLockoutManager implements AccountLockoutInterface
+{
+    /**
+     * Check if a user account is locked.
+     */
+    public function isUserLocked( Authenticatable $user ): bool
+    {
+        return AccountLockout::forUser( $user->getAuthIdentifier() )
+            ->active()
+            ->exists();
+    }
+
+    /**
+     * Check if an IP address is locked.
+     */
+    public function isIpLocked( string $ipAddress ): bool
+    {
+        return AccountLockout::forIp( $ipAddress )
+            ->active()
+            ->exists();
+    }
+
+    /**
+     * Get the active lockout for a user.
+     */
+    public function getUserLockout( Authenticatable $user ): ?AccountLockout
+    {
+        return AccountLockout::forUser( $user->getAuthIdentifier() )
+            ->active()
+            ->first();
+    }
+
+    /**
+     * Get the active lockout for an IP.
+     */
+    public function getIpLockout( string $ipAddress ): ?AccountLockout
+    {
+        return AccountLockout::forIp( $ipAddress )
+            ->active()
+            ->first();
+    }
+
+    /**
+     * Record a failed authentication attempt.
+     */
+    public function recordFailedAttempt( string $trigger, ?Authenticatable $user = null, ?string $ipAddress = null ): array
+    {
+        $config = config( "artisanpack.security-auth.account_lockout.triggers.{$trigger}", [] );
+
+        if ( ! ( $config['enabled'] ?? true ) ) {
+            return ['locked' => false, 'lockout' => null, 'attempts_remaining' => PHP_INT_MAX];
+        }
+
+        // Skip recording attempts for whitelisted users or IPs
+        if ( $this->isWhitelisted( $user, $ipAddress ) ) {
+            return ['locked' => false, 'lockout' => null, 'attempts_remaining' => PHP_INT_MAX];
+        }
+
+        $threshold     = $config['threshold'] ?? 5;
+        $windowMinutes = $config['window_minutes'] ?? 15;
+
+        // Build cache key
+        $keyParts = [$trigger];
+        if ( $user ) {
+            $keyParts[] = 'user_' . $user->getAuthIdentifier();
+        }
+        if ( $ipAddress ) {
+            $keyParts[] = 'ip_' . $ipAddress;
+        }
+        $cacheKey   = 'lockout_attempts_' . implode( '_', $keyParts );
+        $ttlSeconds = $windowMinutes * 60;
+
+        // Use add-if-not-exists to establish the key with TTL for new entries.
+        // This ensures the TTL is set atomically with the initial value,
+        // preventing race conditions where increment happens before TTL is set.
+        Cache::add( $cacheKey, 0, now()->addSeconds( $ttlSeconds ) );
+
+        // Now atomically increment
+        $attempts = Cache::increment( $cacheKey );
+
+        // Handle drivers that don't support increment
+        if ( false === $attempts ) {
+            $attempts = 1;
+            Cache::put( $cacheKey, 1, now()->addSeconds( $ttlSeconds ) );
+        }
+
+        $attemptsRemaining = max( 0, $threshold - $attempts );
+
+        // Check if we should lock
+        if ( $attempts >= $threshold ) {
+            $lockout = $this->createLockout( $trigger, $user, $ipAddress, $attempts );
+
+            return [
+                'locked'             => true,
+                'lockout'            => $lockout,
+                'attempts_remaining' => 0,
+            ];
+        }
+
+        return [
+            'locked'             => false,
+            'lockout'            => null,
+            'attempts_remaining' => $attemptsRemaining,
+        ];
+    }
+
+    /**
+     * Clear failed attempts on successful authentication.
+     */
+    public function clearFailedAttempts( ?Authenticatable $user = null, ?string $ipAddress = null ): void
+    {
+        $triggers = array_keys( config( 'artisanpack.security-auth.account_lockout.triggers', [] ) );
+
+        foreach ( $triggers as $trigger ) {
+            $keyParts = [$trigger];
+            if ( $user ) {
+                $keyParts[] = 'user_' . $user->getAuthIdentifier();
+            }
+            if ( $ipAddress ) {
+                $keyParts[] = 'ip_' . $ipAddress;
+            }
+            Cache::forget( 'lockout_attempts_' . implode( '_', $keyParts ) );
+        }
+    }
+
+    /**
+     * Lock a user account.
+     */
+    public function lockUser( Authenticatable $user, string $reason, string $lockoutType = 'temporary', ?int $durationMinutes = null, array $metadata = [] ): AccountLockout
+    {
+        $durationMinutes = $durationMinutes ?? config( 'artisanpack.security-auth.account_lockout.lockout_duration.initial_minutes', 15 );
+
+        return AccountLockout::create( [
+            'user_id'      => $user->getAuthIdentifier(),
+            'lockout_type' => $lockoutType,
+            'reason'       => $reason,
+            'locked_at'    => now(),
+            'expires_at'   => AccountLockout::TYPE_PERMANENT === $lockoutType ? null : now()->addMinutes( $durationMinutes ),
+            'metadata'     => $metadata,
+        ] );
+    }
+
+    /**
+     * Lock an IP address.
+     */
+    public function lockIp( string $ipAddress, int $durationMinutes, string $reason, string $lockoutType = 'temporary', array $metadata = [] ): AccountLockout
+    {
+        return AccountLockout::create( [
+            'ip_address'   => $ipAddress,
+            'lockout_type' => $lockoutType,
+            'reason'       => $reason,
+            'locked_at'    => now(),
+            'expires_at'   => AccountLockout::TYPE_PERMANENT === $lockoutType ? null : now()->addMinutes( $durationMinutes ),
+            'metadata'     => $metadata,
+        ] );
+    }
+
+    /**
+     * Unlock a user account.
+     */
+    public function unlockUser( Authenticatable $user, ?Authenticatable $unlockedBy = null, ?string $reason = null ): bool
+    {
+        $lockout = $this->getUserLockout( $user );
+
+        if ( ! $lockout ) {
+            return false;
+        }
+
+        $lockout->unlock( $unlockedBy?->getAuthIdentifier(), $reason );
+
+        return true;
+    }
+
+    /**
+     * Unlock an IP address.
+     */
+    public function unlockIp( string $ipAddress, ?Authenticatable $unlockedBy = null, ?string $reason = null ): bool
+    {
+        $lockout = $this->getIpLockout( $ipAddress );
+
+        if ( ! $lockout ) {
+            return false;
+        }
+
+        $lockout->unlock( $unlockedBy?->getAuthIdentifier(), $reason );
+
+        return true;
+    }
+
+    /**
+     * Get remaining lockout duration in seconds.
+     */
+    public function getRemainingLockoutDuration( AccountLockout $lockout ): int
+    {
+        return $lockout->getRemainingSeconds();
+    }
+
+    /**
+     * Calculate progressive lockout duration based on lockout count.
+     */
+    public function calculateProgressiveDuration( int $lockoutCount ): int
+    {
+        $config         = config( 'artisanpack.security-auth.account_lockout', [] );
+        $initialMinutes = $config['lockout_duration']['initial_minutes'] ?? 15;
+        $maxMinutes     = $config['progressive']['max_duration'] ?? 1440;
+        $multiplier     = $config['progressive']['multiplier'] ?? 2.0;
+        $progressive    = $config['progressive']['enabled'] ?? true;
+
+        if ( ! $progressive ) {
+            return $initialMinutes;
+        }
+
+        // Ensure lockoutCount is at least 1 to avoid negative exponents
+        // which would result in duration smaller than initial_minutes
+        if ( $lockoutCount < 1 ) {
+            $lockoutCount = 1;
+        }
+
+        // Calculate progressive duration based on count
+        // First lockout (count=1) = initial
+        // Second lockout (count=2) = initial * multiplier
+        // Third lockout (count=3) = initial * multiplier^2
+        $duration = (int) ( $initialMinutes * pow( $multiplier, $lockoutCount - 1 ) );
+
+        return min( $duration, $maxMinutes );
+    }
+
+    /**
+     * Calculate progressive lockout duration for a user.
+     */
+    public function calculateProgressiveDurationForUser( Authenticatable $user ): int
+    {
+        // Count recent lockouts
+        $recentLockouts = $this->getRecentLockoutCount( $user );
+
+        return $this->calculateProgressiveDuration( $recentLockouts + 1 );
+    }
+
+    /**
+     * Check if user should be permanently locked.
+     */
+    public function shouldPermanentlyLock( Authenticatable $user ): bool
+    {
+        $config = config( 'artisanpack.security-auth.account_lockout.permanent_lockout', [] );
+
+        if ( ! ( $config['enabled'] ?? true ) ) {
+            return false;
+        }
+
+        $threshold = $config['after_temporary_count'] ?? 5;
+
+        // Count temporary lockouts in last 24 hours
+        $temporaryCount = AccountLockout::where( 'user_id', $user->getAuthIdentifier() )
+            ->where( 'lockout_type', AccountLockout::TYPE_TEMPORARY )
+            ->where( 'created_at', '>=', now()->subHours( 24 ) )
+            ->count();
+
+        return $temporaryCount >= $threshold;
+    }
+
+    /**
+     * Get lockout history for a user.
+     */
+    public function getLockoutHistory( Authenticatable $user ): Collection
+    {
+        return AccountLockout::where( 'user_id', $user->getAuthIdentifier() )
+            ->orderByDesc( 'created_at' )
+            ->get();
+    }
+
+    /**
+     * Process automatic unlock of expired lockouts.
+     */
+    public function processExpiredLockouts(): int
+    {
+        $expired = AccountLockout::expired()->get();
+        $count   = 0;
+
+        foreach ( $expired as $lockout ) {
+            $lockout->unlock( null, 'Automatic unlock - lockout expired' );
+            $count++;
+        }
+
+        return $count;
+    }
+
+    /**
+     * Check if an entity is whitelisted.
+     */
+    public function isWhitelisted( ?Authenticatable $user = null, ?string $ipAddress = null ): bool
+    {
+        $config = config( 'artisanpack.security-auth.account_lockout.whitelist', [] );
+
+        if ( $ipAddress && in_array( $ipAddress, $config['ips'] ?? [] ) ) {
+            return true;
+        }
+
+        if ( $user && in_array( $user->getAuthIdentifier(), $config['users'] ?? [] ) ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Create a lockout.
+     */
+    protected function createLockout( string $trigger, ?Authenticatable $user, ?string $ipAddress, int $failedAttempts ): AccountLockout
+    {
+        $durationMinutes = $this->calculateDuration( $user );
+        $lockoutType     = $this->determineLockoutType( $user );
+
+        $lockout = AccountLockout::create( [
+            'user_id'         => $user?->getAuthIdentifier(),
+            'ip_address'      => $ipAddress,
+            'lockout_type'    => $lockoutType,
+            'reason'          => "Too many failed {$trigger} attempts",
+            'failed_attempts' => $failedAttempts,
+            'locked_at'       => now(),
+            'expires_at'      => AccountLockout::TYPE_PERMANENT === $lockoutType ? null : now()->addMinutes( $durationMinutes ),
+            'metadata'        => [
+                'trigger' => $trigger,
+            ],
+        ] );
+
+        // Clear the attempts counter
+        $this->clearFailedAttempts( $user, $ipAddress );
+
+        // Dispatch the AccountLocked event so listeners can respond
+        event( new AccountLocked( $lockout, $user, $ipAddress ) );
+
+        return $lockout;
+    }
+
+    /**
+     * Determine the lockout type.
+     */
+    protected function determineLockoutType( ?Authenticatable $user ): string
+    {
+        if ( ! $user ) {
+            return AccountLockout::TYPE_TEMPORARY;
+        }
+
+        // Check if should be permanent
+        if ( $this->shouldPermanentlyLock( $user ) ) {
+            return AccountLockout::TYPE_PERMANENT;
+        }
+
+        // Check soft lockout threshold
+        $softConfig = config( 'artisanpack.security-auth.account_lockout.soft_lockout', [] );
+        if ( $softConfig['enabled'] ?? true ) {
+            $recentLockouts = $this->getRecentLockoutCount( $user );
+            if ( 0 === $recentLockouts ) {
+                return AccountLockout::TYPE_SOFT;
+            }
+        }
+
+        return AccountLockout::TYPE_TEMPORARY;
+    }
+
+    /**
+     * Get recent lockout count for progressive lockout.
+     */
+    protected function getRecentLockoutCount( ?Authenticatable $user ): int
+    {
+        if ( ! $user ) {
+            return 0;
+        }
+
+        return AccountLockout::where( 'user_id', $user->getAuthIdentifier())
+            ->where( 'created_at', '>=', now()->subHours( 24))
+            ->count();
+    }
+
+    /**
+     * Calculate duration for a lockout.
+     */
+    protected function calculateDuration( ?Authenticatable $user): int
+    {
+        if ( ! $user) {
+            return config( 'artisanpack.security-auth.account_lockout.lockout_duration.initial_minutes', 15);
+        }
+
+        return $this->calculateProgressiveDurationForUser( $user);
+    }
+}

--- a/src/Authentication/Lockout/AccountLockoutManager.php
+++ b/src/Authentication/Lockout/AccountLockoutManager.php
@@ -91,16 +91,28 @@ class AccountLockoutManager implements AccountLockoutInterface
         // Now atomically increment
         $attempts = Cache::increment( $cacheKey );
 
-        // Handle drivers that don't support increment
+        // Handle drivers that don't support increment — read, +1, write.
         if ( false === $attempts ) {
-            $attempts = 1;
-            Cache::put( $cacheKey, 1, now()->addSeconds( $ttlSeconds ) );
+            $attempts = (int) Cache::get( $cacheKey, 0 ) + 1;
+            Cache::put( $cacheKey, $attempts, now()->addSeconds( $ttlSeconds ) );
         }
 
         $attemptsRemaining = max( 0, $threshold - $attempts );
 
         // Check if we should lock
         if ( $attempts >= $threshold ) {
+            // Reuse an existing active lockout if one is already in flight so
+            // concurrent requests don't insert duplicates and re-fire AccountLocked.
+            $existing = $this->getActiveLockoutForSubject( $user, $ipAddress );
+
+            if ( null !== $existing ) {
+                return [
+                    'locked'             => true,
+                    'lockout'            => $existing,
+                    'attempts_remaining' => 0,
+                ];
+            }
+
             $lockout = $this->createLockout( $trigger, $user, $ipAddress, $attempts );
 
             return [
@@ -304,15 +316,36 @@ class AccountLockoutManager implements AccountLockoutInterface
     {
         $config = config( 'artisanpack.security-auth.account_lockout.whitelist', [] );
 
-        if ( $ipAddress && in_array( $ipAddress, $config['ips'] ?? [] ) ) {
+        $ips   = array_map( 'strval', (array) ( $config['ips'] ?? [] ) );
+        $users = array_map( 'strval', (array) ( $config['users'] ?? [] ) );
+
+        if ( $ipAddress && in_array( (string) $ipAddress, $ips, true ) ) {
             return true;
         }
 
-        if ( $user && in_array( $user->getAuthIdentifier(), $config['users'] ?? [] ) ) {
+        if ( $user && in_array( (string) $user->getAuthIdentifier(), $users, true ) ) {
             return true;
         }
 
         return false;
+    }
+
+    /**
+     * Find a still-active lockout for the given user or IP, if one exists.
+     */
+    protected function getActiveLockoutForSubject( ?Authenticatable $user, ?string $ipAddress ): ?AccountLockout
+    {
+        $query = AccountLockout::active();
+
+        if ( $user ) {
+            return $query->where( 'user_id', $user->getAuthIdentifier() )->first();
+        }
+
+        if ( $ipAddress ) {
+            return $query->where( 'ip_address', $ipAddress )->first();
+        }
+
+        return null;
     }
 
     /**
@@ -380,17 +413,17 @@ class AccountLockoutManager implements AccountLockoutInterface
             return 0;
         }
 
-        return AccountLockout::where( 'user_id', $user->getAuthIdentifier())
-            ->where( 'created_at', '>=', now()->subHours( 24))
+        return AccountLockout::where( 'user_id', $user->getAuthIdentifier() )
+            ->where( 'created_at', '>=', now()->subHours( 24 ) )
             ->count();
     }
 
     /**
      * Calculate duration for a lockout.
      */
-    protected function calculateDuration( ?Authenticatable $user): int
+    protected function calculateDuration( ?Authenticatable $user ): int
     {
-        if ( ! $user) {
+        if ( ! $user ) {
             return config( 'artisanpack.security-auth.account_lockout.lockout_duration.initial_minutes', 15);
         }
 

--- a/src/Authentication/Session/AdvancedSessionManager.php
+++ b/src/Authentication/Session/AdvancedSessionManager.php
@@ -314,14 +314,18 @@ class AdvancedSessionManager implements SessionSecurityInterface
      */
     protected function validateIpBinding( ?string $sessionIp, ?string $requestIp, string $strictness ): bool
     {
-        if ( ! $sessionIp || ! $requestIp ) {
+        $strictness = strtolower( $strictness );
+
+        // 'none' means the binding is intentionally off — only branch where
+        // missing metadata is acceptable.
+        if ( 'none' === $strictness ) {
             return true;
         }
 
-        $strictness = strtolower( $strictness );
-
-        if ( 'none' === $strictness ) {
-            return true;
+        // Otherwise fail closed when either side is missing rather than
+        // silently waving the request through.
+        if ( ! $sessionIp || ! $requestIp ) {
+            return false;
         }
 
         if ( 'exact' === $strictness ) {
@@ -354,14 +358,14 @@ class AdvancedSessionManager implements SessionSecurityInterface
      */
     protected function validateUserAgentBinding( ?string $sessionUa, ?string $requestUa, string $strictness ): bool
     {
-        if ( ! $sessionUa || ! $requestUa ) {
-            return true;
-        }
-
         $strictness = strtolower( $strictness );
 
         if ( 'none' === $strictness ) {
             return true;
+        }
+
+        if ( ! $sessionUa || ! $requestUa ) {
+            return false;
         }
 
         if ( 'exact' === $strictness ) {
@@ -372,6 +376,12 @@ class AdvancedSessionManager implements SessionSecurityInterface
         if ( 'browser_only' === $strictness ) {
             $sessionBrowser = $this->extractBrowser( $sessionUa );
             $requestBrowser = $this->extractBrowser( $requestUa );
+
+            // null === null would otherwise pass two unrecognised UAs;
+            // treat unparseable as a mismatch.
+            if ( null === $sessionBrowser || null === $requestBrowser ) {
+                return false;
+            }
 
             return $sessionBrowser === $requestBrowser;
         }

--- a/src/Authentication/Session/AdvancedSessionManager.php
+++ b/src/Authentication/Session/AdvancedSessionManager.php
@@ -32,7 +32,7 @@ class AdvancedSessionManager implements SessionSecurityInterface
         $absoluteMinutes = config( 'artisanpack.security-auth.advanced_sessions.timeouts.absolute_minutes', 480 );
         $expiresAt       = now()->addMinutes( $absoluteMinutes );
 
-        return UserSession::create( [
+        $session = UserSession::create( [
             'id'               => $sessionId,
             'user_id'          => $user->getAuthIdentifier(),
             'device_id'        => $deviceId,
@@ -45,6 +45,12 @@ class AdvancedSessionManager implements SessionSecurityInterface
             'expires_at'       => $expiresAt,
             'created_at'       => now(),
         ] );
+
+        // Persist the new session id where getCurrentSession() looks for it,
+        // otherwise the DB row exists but the request can't find its own session.
+        session()->put( 'advanced_session_id', $session->id );
+
+        return $session;
     }
 
     /**
@@ -115,6 +121,9 @@ class AdvancedSessionManager implements SessionSecurityInterface
 
             // Delete the old session record
             UserSession::where( 'id', $oldId )->delete();
+
+            // Sync the session store so subsequent requests resolve the rotated row.
+            session()->put( 'advanced_session_id', $newSession->id );
 
             return $newSession;
         } );
@@ -248,7 +257,7 @@ class AdvancedSessionManager implements SessionSecurityInterface
             return false;
         }
 
-        return $session->last_activity_at->addMinutes( $warningMinutes )->isPast();
+        return $session->last_activity_at->copy()->addMinutes( $warningMinutes )->isPast();
     }
 
     /**

--- a/src/Authentication/Session/AdvancedSessionManager.php
+++ b/src/Authentication/Session/AdvancedSessionManager.php
@@ -110,7 +110,7 @@ class AdvancedSessionManager implements SessionSecurityInterface
                 'is_current'       => $session->is_current,
                 'last_activity_at' => now(),
                 'expires_at'       => $session->expires_at,
-                'created_at'       => $session->created_at,
+                'created_at'       => now(),
             ] );
 
             // Delete the old session record
@@ -274,7 +274,7 @@ class AdvancedSessionManager implements SessionSecurityInterface
             return false;
         }
 
-        return $session->created_at->addMinutes( $intervalMinutes )->isPast();
+        return $session->created_at->copy()->addMinutes( $intervalMinutes )->isPast();
     }
 
     /**
@@ -364,10 +364,10 @@ class AdvancedSessionManager implements SessionSecurityInterface
         if ( preg_match( '/Chrome\/\d+/i', $userAgent ) ) {
             return 'Chrome';
         }
-        if ( preg_match( '/Firefox\/\d+/i', $userAgent)) {
+        if ( preg_match( '/Firefox\/\d+/i', $userAgent ) ) {
             return 'Firefox';
         }
-        if ( preg_match( '/Safari\/\d+/i', $userAgent) && ! str_contains( $userAgent, 'Chrome')) {
+        if ( preg_match( '/Safari\/\d+/i', $userAgent ) && ! str_contains( $userAgent, 'Chrome' ) ) {
             return 'Safari';
         }
         if ( preg_match( '/Edg\/\d+/i', $userAgent)) {

--- a/src/Authentication/Session/AdvancedSessionManager.php
+++ b/src/Authentication/Session/AdvancedSessionManager.php
@@ -1,0 +1,379 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Authentication\Session;
+
+use ArtisanPackUI\SecurityAuth\Authentication\Contracts\SessionSecurityInterface;
+use ArtisanPackUI\SecurityAuth\Models\UserSession;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class AdvancedSessionManager implements SessionSecurityInterface
+{
+    /**
+     * Create a new secure session for the user.
+     */
+    public function createSession( Authenticatable $user, Request $request, string $authMethod, array $metadata = [] ): UserSession
+    {
+        // Generate session ID
+        $sessionId = Str::random( 64 );
+
+        // Get device if available
+        $deviceId = $metadata['device_id'] ?? null;
+
+        // Get location
+        $location = $this->getLocationFromRequest( $request );
+
+        // Calculate expiration
+        $absoluteMinutes = config( 'artisanpack.security-auth.advanced_sessions.timeouts.absolute_minutes', 480 );
+        $expiresAt       = now()->addMinutes( $absoluteMinutes );
+
+        return UserSession::create( [
+            'id'               => $sessionId,
+            'user_id'          => $user->getAuthIdentifier(),
+            'device_id'        => $deviceId,
+            'ip_address'       => $request->ip(),
+            'user_agent'       => $request->userAgent(),
+            'location'         => $location,
+            'auth_method'      => $authMethod,
+            'is_current'       => true,
+            'last_activity_at' => now(),
+            'expires_at'       => $expiresAt,
+            'created_at'       => now(),
+        ] );
+    }
+
+    /**
+     * Validate session bindings.
+     */
+    public function validateSessionBindings( UserSession $session, Request $request ): array
+    {
+        $violations = [];
+        $config     = config( 'artisanpack.security-auth.advanced_sessions.binding', [] );
+
+        // IP address binding
+        if ( $config['ip_address']['enabled'] ?? true ) {
+            $strictness = $config['ip_address']['strictness'] ?? 'subnet';
+            if ( ! $this->validateIpBinding( $session->ip_address, $request->ip(), $strictness ) ) {
+                $violations[] = 'ip_address';
+            }
+        }
+
+        // User agent binding
+        if ( $config['user_agent']['enabled'] ?? true ) {
+            $strictness = $config['user_agent']['strictness'] ?? 'exact';
+            if ( ! $this->validateUserAgentBinding( $session->user_agent, $request->userAgent(), $strictness ) ) {
+                $violations[] = 'user_agent_mismatch';
+            }
+        }
+
+        return [
+            'valid'      => empty( $violations ),
+            'violations' => $violations,
+        ];
+    }
+
+    /**
+     * Update session activity timestamp.
+     */
+    public function touchSession( UserSession $session ): void
+    {
+        $session->touchActivity();
+    }
+
+    /**
+     * Rotate the session ID by creating a new session and deleting the old one.
+     *
+     * This method creates a new session record with a fresh ID while preserving
+     * all session metadata, then deletes the old session record. The operation
+     * is wrapped in a transaction to ensure atomicity.
+     */
+    public function rotateSession( UserSession $session ): UserSession
+    {
+        return DB::transaction( function () use ( $session ) {
+            $oldId = $session->id;
+
+            // Create new session with fresh ID, copying all relevant attributes
+            $newSession = UserSession::create( [
+                'id'               => Str::random( 64 ),
+                'user_id'          => $session->user_id,
+                'device_id'        => $session->device_id,
+                'ip_address'       => $session->ip_address,
+                'user_agent'       => $session->user_agent,
+                'location'         => $session->location,
+                'payload'          => $session->payload,
+                'auth_method'      => $session->auth_method,
+                'is_current'       => $session->is_current,
+                'last_activity_at' => now(),
+                'expires_at'       => $session->expires_at,
+                'created_at'       => $session->created_at,
+            ] );
+
+            // Delete the old session record
+            UserSession::where( 'id', $oldId )->delete();
+
+            return $newSession;
+        } );
+    }
+
+    /**
+     * Terminate a specific session.
+     */
+    public function terminateSession( string $sessionId ): bool
+    {
+        return (bool) UserSession::where( 'id', $sessionId )->delete();
+    }
+
+    /**
+     * Terminate all sessions except the current one.
+     */
+    public function terminateOtherSessions( Authenticatable $user, string $currentSessionId ): int
+    {
+        return UserSession::where( 'user_id', $user->getAuthIdentifier() )
+            ->where( 'id', '!=', $currentSessionId )
+            ->delete();
+    }
+
+    /**
+     * Terminate all sessions for a user.
+     */
+    public function terminateAllSessions( Authenticatable $user ): int
+    {
+        return UserSession::where( 'user_id', $user->getAuthIdentifier() )->delete();
+    }
+
+    /**
+     * Get all active sessions for a user.
+     */
+    public function getUserSessions( Authenticatable $user ): Collection
+    {
+        return UserSession::where( 'user_id', $user->getAuthIdentifier() )
+            ->active()
+            ->latestActivity()
+            ->get();
+    }
+
+    /**
+     * Get the current session.
+     */
+    public function getCurrentSession( Request $request ): ?UserSession
+    {
+        // Look up by Laravel session ID stored in metadata, or by is_current flag
+        $customSessionId = session()->get( 'advanced_session_id' );
+        
+        if ( ! $customSessionId ) {
+            return null;
+        }
+
+        return UserSession::where( 'id', $customSessionId )->first();
+    }
+
+    /**
+     * Check if concurrent session limit is exceeded.
+     */
+    public function isSessionLimitExceeded( Authenticatable $user ): bool
+    {
+        $maxSessions  = config( 'artisanpack.security-auth.advanced_sessions.concurrent_sessions.max_sessions', 5 );
+        $currentCount = UserSession::where( 'user_id', $user->getAuthIdentifier() )
+            ->active()
+            ->count();
+
+        return $currentCount >= $maxSessions;
+    }
+
+    /**
+     * Enforce concurrent session limit.
+     */
+    public function enforceSessionLimit( Authenticatable $user ): int
+    {
+        if ( ! config( 'artisanpack.security-auth.advanced_sessions.concurrent_sessions.enabled', true ) ) {
+            return 0;
+        }
+
+        $maxSessions = config( 'artisanpack.security-auth.advanced_sessions.concurrent_sessions.max_sessions', 5 );
+        $strategy    = config( 'artisanpack.security-auth.advanced_sessions.concurrent_sessions.strategy', 'oldest' );
+
+        $activeSessions = UserSession::where( 'user_id', $user->getAuthIdentifier() )
+            ->active()
+            ->orderBy( 'created_at', 'oldest' === $strategy ? 'asc' : 'desc' )
+            ->get();
+
+        $terminatedCount = 0;
+        $excessCount     = $activeSessions->count() - $maxSessions + 1; // +1 for the new session
+
+        if ( $excessCount > 0 ) {
+            $sessionsToTerminate = $activeSessions->take( $excessCount );
+
+            foreach ( $sessionsToTerminate as $session ) {
+                $session->delete();
+                $terminatedCount++;
+            }
+        }
+
+        return $terminatedCount;
+    }
+
+    /**
+     * Check if session is expired.
+     */
+    public function isSessionExpired( UserSession $session ): bool
+    {
+        // Check absolute expiration
+        if ( $session->expires_at && $session->expires_at->isPast() ) {
+            return true;
+        }
+
+        // Check idle timeout only if last_activity_at is set
+        if ( $session->last_activity_at ) {
+            $idleMinutes = config( 'artisanpack.security-auth.advanced_sessions.timeouts.idle_minutes', 30 );
+
+            return $session->isIdle( $idleMinutes );
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if session is approaching idle timeout.
+     */
+    public function isApproachingIdleTimeout( UserSession $session ): bool
+    {
+        $warningMinutes = config( 'artisanpack.security-auth.advanced_sessions.timeouts.idle_warning_minutes', 25 );
+
+        if ( ! $session->last_activity_at ) {
+            return false;
+        }
+
+        return $session->last_activity_at->addMinutes( $warningMinutes )->isPast();
+    }
+
+    /**
+     * Prune expired sessions.
+     */
+    public function pruneExpiredSessions(): int
+    {
+        return UserSession::expired()->delete();
+    }
+
+    /**
+     * Check if session should be rotated.
+     */
+    public function shouldRotateSession( UserSession $session ): bool
+    {
+        if ( ! config( 'artisanpack.security-auth.advanced_sessions.rotation.enabled', true ) ) {
+            return false;
+        }
+
+        $intervalMinutes = config( 'artisanpack.security-auth.advanced_sessions.rotation.interval_minutes', 15 );
+
+        if ( ! $session->created_at ) {
+            return false;
+        }
+
+        return $session->created_at->addMinutes( $intervalMinutes )->isPast();
+    }
+
+    /**
+     * Get location from request (simplified).
+     *
+     * @return array<string, mixed>|null
+     */
+    protected function getLocationFromRequest( Request $request ): ?array
+    {
+        return [
+            'ip'      => $request->ip(),
+            'country' => null,
+            'region'  => null,
+            'city'    => null,
+        ];
+    }
+
+    /**
+     * Validate IP address binding.
+     */
+    protected function validateIpBinding( ?string $sessionIp, ?string $requestIp, string $strictness ): bool
+    {
+        if ( ! $sessionIp || ! $requestIp ) {
+            return true;
+        }
+
+        if ( 'none' === $strictness ) {
+            return true;
+        }
+
+        if ( 'exact' === $strictness ) {
+            return $sessionIp === $requestIp;
+        }
+
+        // Subnet matching
+        if ( 'subnet' === $strictness ) {
+            // For IPv4, compare first 3 octets
+            if ( filter_var( $sessionIp, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 )
+                && filter_var( $requestIp, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
+                $sessionParts = explode( '.', $sessionIp );
+                $requestParts = explode( '.', $requestIp );
+
+                return array_slice( $sessionParts, 0, 3 ) === array_slice( $requestParts, 0, 3 );
+            }
+
+            // For IPv6, compare first 64 bits
+            // Simplified - in production use proper subnet comparison
+            return $sessionIp === $requestIp;
+        }
+
+        return true;
+    }
+
+    /**
+     * Validate user agent binding.
+     */
+    protected function validateUserAgentBinding( ?string $sessionUa, ?string $requestUa, string $strictness ): bool
+    {
+        if ( ! $sessionUa || ! $requestUa ) {
+            return true;
+        }
+
+        if ( 'none' === $strictness ) {
+            return true;
+        }
+
+        if ( 'exact' === $strictness ) {
+            return $sessionUa === $requestUa;
+        }
+
+        // Browser only - check if browser matches
+        if ( 'browser_only' === $strictness ) {
+            $sessionBrowser = $this->extractBrowser( $sessionUa );
+            $requestBrowser = $this->extractBrowser( $requestUa );
+
+            return $sessionBrowser === $requestBrowser;
+        }
+
+        return true;
+    }
+
+    /**
+     * Extract browser from user agent.
+     */
+    protected function extractBrowser( string $userAgent ): ?string
+    {
+        if ( preg_match( '/Chrome\/\d+/i', $userAgent ) ) {
+            return 'Chrome';
+        }
+        if ( preg_match( '/Firefox\/\d+/i', $userAgent)) {
+            return 'Firefox';
+        }
+        if ( preg_match( '/Safari\/\d+/i', $userAgent) && ! str_contains( $userAgent, 'Chrome')) {
+            return 'Safari';
+        }
+        if ( preg_match( '/Edg\/\d+/i', $userAgent)) {
+            return 'Edge';
+        }
+
+        return null;
+    }
+}

--- a/src/Authentication/Session/AdvancedSessionManager.php
+++ b/src/Authentication/Session/AdvancedSessionManager.php
@@ -318,6 +318,8 @@ class AdvancedSessionManager implements SessionSecurityInterface
             return true;
         }
 
+        $strictness = strtolower( $strictness );
+
         if ( 'none' === $strictness ) {
             return true;
         }
@@ -342,7 +344,9 @@ class AdvancedSessionManager implements SessionSecurityInterface
             return $sessionIp === $requestIp;
         }
 
-        return true;
+        // Unknown strictness: fail closed so a config typo can't silently
+        // disable IP binding.
+        return false;
     }
 
     /**
@@ -353,6 +357,8 @@ class AdvancedSessionManager implements SessionSecurityInterface
         if ( ! $sessionUa || ! $requestUa ) {
             return true;
         }
+
+        $strictness = strtolower( $strictness );
 
         if ( 'none' === $strictness ) {
             return true;
@@ -370,7 +376,8 @@ class AdvancedSessionManager implements SessionSecurityInterface
             return $sessionBrowser === $requestBrowser;
         }
 
-        return true;
+        // Unknown strictness: fail closed (same reasoning as validateIpBinding).
+        return false;
     }
 
     /**

--- a/src/Authentication/Session/AdvancedSessionManager.php
+++ b/src/Authentication/Session/AdvancedSessionManager.php
@@ -361,6 +361,11 @@ class AdvancedSessionManager implements SessionSecurityInterface
      */
     protected function extractBrowser( string $userAgent ): ?string
     {
+        // Edge UAs include "Chrome/" too, so this needs to win before the
+        // Chrome branch.
+        if ( preg_match( '/Edg\/\d+/i', $userAgent ) ) {
+            return 'Edge';
+        }
         if ( preg_match( '/Chrome\/\d+/i', $userAgent ) ) {
             return 'Chrome';
         }
@@ -369,9 +374,6 @@ class AdvancedSessionManager implements SessionSecurityInterface
         }
         if ( preg_match( '/Safari\/\d+/i', $userAgent ) && ! str_contains( $userAgent, 'Chrome' ) ) {
             return 'Safari';
-        }
-        if ( preg_match( '/Edg\/\d+/i', $userAgent)) {
-            return 'Edge';
         }
 
         return null;

--- a/src/Authentication/Session/AdvancedSessionManager.php
+++ b/src/Authentication/Session/AdvancedSessionManager.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 class AdvancedSessionManager implements SessionSecurityInterface
 {
@@ -100,33 +101,40 @@ class AdvancedSessionManager implements SessionSecurityInterface
      */
     public function rotateSession( UserSession $session ): UserSession
     {
-        return DB::transaction( function () use ( $session ) {
-            $oldId = $session->id;
+        $newSession = DB::transaction( function () use ( $session ) {
+            // SELECT ... FOR UPDATE so two parallel rotations of the same row
+            // serialize instead of inserting duplicate replacement rows. Read
+            // attributes from the locked instance (not the stale caller copy).
+            $locked = UserSession::query()->lockForUpdate()->find( $session->id );
 
-            // Create new session with fresh ID, copying all relevant attributes
+            if ( null === $locked ) {
+                throw new RuntimeException( 'Session has already been rotated or terminated.' );
+            }
+
             $newSession = UserSession::create( [
                 'id'               => Str::random( 64 ),
-                'user_id'          => $session->user_id,
-                'device_id'        => $session->device_id,
-                'ip_address'       => $session->ip_address,
-                'user_agent'       => $session->user_agent,
-                'location'         => $session->location,
-                'payload'          => $session->payload,
-                'auth_method'      => $session->auth_method,
-                'is_current'       => $session->is_current,
+                'user_id'          => $locked->user_id,
+                'device_id'        => $locked->device_id,
+                'ip_address'       => $locked->ip_address,
+                'user_agent'       => $locked->user_agent,
+                'location'         => $locked->location,
+                'payload'          => $locked->payload,
+                'auth_method'      => $locked->auth_method,
+                'is_current'       => $locked->is_current,
                 'last_activity_at' => now(),
-                'expires_at'       => $session->expires_at,
+                'expires_at'       => $locked->expires_at,
                 'created_at'       => now(),
             ] );
 
-            // Delete the old session record
-            UserSession::where( 'id', $oldId )->delete();
-
-            // Sync the session store so subsequent requests resolve the rotated row.
-            session()->put( 'advanced_session_id', $newSession->id );
+            UserSession::where( 'id', $locked->id )->delete();
 
             return $newSession;
         } );
+
+        // Session-store writes belong outside the DB transaction.
+        session()->put( 'advanced_session_id', $newSession->id );
+
+        return $newSession;
     }
 
     /**

--- a/src/Console/Commands/ManageAccountLockout.php
+++ b/src/Console/Commands/ManageAccountLockout.php
@@ -1,0 +1,186 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Console\Commands;
+
+use ArtisanPackUI\SecurityAuth\Authentication\Lockout\AccountLockoutManager;
+use ArtisanPackUI\SecurityAuth\Models\AccountLockout;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\App;
+
+class ManageAccountLockout extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'security:lockout
+                            {action : The action to perform (list|unlock|lock)}
+                            {--user= : User ID or email for user-specific actions}
+                            {--ip= : IP address for IP-specific actions}
+                            {--reason= : Reason for locking}
+                            {--duration=60 : Lock duration in minutes}
+                            {--permanent : Create a permanent lock}
+                            {--all : Apply to all active lockouts}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Manage account lockouts';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $action = $this->argument( 'action' );
+
+        return match ( $action ) {
+            'list'   => $this->listLockouts(),
+            'unlock' => $this->unlockAccount(),
+            'lock'   => $this->lockAccount(),
+            default  => $this->invalidAction( $action ),
+        };
+    }
+
+    protected function listLockouts(): int
+    {
+        $query = AccountLockout::active();
+
+        if ( $userId = $this->option( 'user' ) ) {
+            $user = $this->findUser( $userId );
+            if ( ! $user ) {
+                return self::FAILURE;
+            }
+            $query->where( 'user_id', $user->id );
+        }
+
+        if ( $ip = $this->option( 'ip' ) ) {
+            $query->where( 'ip_address', $ip );
+        }
+
+        $lockouts = $query->get();
+
+        if ( $lockouts->isEmpty() ) {
+            $this->info( 'No active lockouts found.' );
+
+            return self::SUCCESS;
+        }
+
+        $this->table(
+            ['ID', 'User ID', 'IP Address', 'Type', 'Reason', 'Expires At'],
+            $lockouts->map( fn ( $l ) => [
+                $l->id,
+                $l->user_id ?? '-',
+                $l->ip_address ?? '-',
+                $l->lockout_type,
+                \Illuminate\Support\Str::limit( $l->reason, 30 ),
+                $l->expires_at?->format( 'Y-m-d H:i:s' ) ?? 'Never',
+            ] ),
+        );
+
+        return self::SUCCESS;
+    }
+
+    protected function unlockAccount(): int
+    {
+        /** @var AccountLockoutManager $lockoutManager */
+        $lockoutManager = App::make( AccountLockoutManager::class );
+
+        if ( $this->option( 'all' ) ) {
+            $count = AccountLockout::active()->update( [
+                'is_active'   => false,
+                'unlocked_at' => now(),
+                'unlocked_by' => 'console',
+            ] );
+            $this->info( "Unlocked {$count} account(s)." );
+
+            return self::SUCCESS;
+        }
+
+        if ( $userId = $this->option( 'user' ) ) {
+            $user = $this->findUser( $userId );
+            if ( ! $user ) {
+                return self::FAILURE;
+            }
+
+            $lockoutManager->unlockUser( $user );
+            $this->info( "Unlocked account for user: {$user->email}" );
+
+            return self::SUCCESS;
+        }
+
+        if ( $ip = $this->option( 'ip' ) ) {
+            $lockoutManager->unlockIp( $ip );
+            $this->info( "Unlocked IP address: {$ip}" );
+
+            return self::SUCCESS;
+        }
+
+        $this->error( 'Please specify --user, --ip, or --all' );
+
+        return self::FAILURE;
+    }
+
+    protected function lockAccount(): int
+    {
+        /** @var AccountLockoutManager $lockoutManager */
+        $lockoutManager = App::make( AccountLockoutManager::class );
+
+        $reason   = $this->option( 'reason' ) ?? 'Locked via console command';
+        $duration = $this->option( 'permanent' ) ? null : (int) $this->option( 'duration' );
+
+        if ( $userId = $this->option( 'user' ) ) {
+            $user = $this->findUser( $userId );
+            if ( ! $user ) {
+                return self::FAILURE;
+            }
+
+            $lockoutManager->lockUser( $user, $duration, $reason );
+            $durationText = $duration ? "{$duration} minutes" : 'permanently';
+            $this->info( "Locked account for user: {$user->email} ({$durationText})" );
+
+            return self::SUCCESS;
+        }
+
+        if ( $ip = $this->option( 'ip' ) ) {
+            $lockoutManager->lockIp( $ip, $duration, $reason );
+            $durationText = $duration ? "{$duration} minutes" : 'permanently';
+            $this->info( "Locked IP address: {$ip} ({$durationText})" );
+
+            return self::SUCCESS;
+        }
+
+        $this->error( 'Please specify --user or --ip' );
+
+        return self::FAILURE;
+    }
+
+    protected function findUser( string $identifier ): mixed
+    {
+        $userModel = config( 'auth.providers.users.model' );
+        $user      = $userModel::where( 'id', $identifier )
+            ->orWhere( 'email', $identifier )
+            ->first();
+
+        if ( ! $user ) {
+            $this->error( "User not found: {$identifier}" );
+
+            return null;
+        }
+
+        return $user;
+    }
+
+    protected function invalidAction( string $action): int
+    {
+        $this->error( "Invalid action: {$action}");
+        $this->line( 'Valid actions: list, unlock, lock');
+
+        return self::FAILURE;
+    }
+}

--- a/src/Console/Commands/ManageAccountLockout.php
+++ b/src/Console/Commands/ManageAccountLockout.php
@@ -92,11 +92,16 @@ class ManageAccountLockout extends Command
         $lockoutManager = App::make( AccountLockoutManager::class );
 
         if ( $this->option( 'all' ) ) {
-            $count = AccountLockout::active()->update( [
-                'is_active'   => false,
-                'unlocked_at' => now(),
-                'unlocked_by' => 'console',
-            ] );
+            // is_active is computed (see AccountLockout::isActive()) and not
+            // a real column; unlocked_by expects an int FK, not a string.
+            // Iterate so the model's unlock() contract is preserved.
+            $count = 0;
+
+            AccountLockout::active()->each( function ( AccountLockout $lockout ) use ( &$count ): void {
+                $lockout->unlock( null, 'Unlocked via console command' );
+                $count++;
+            } );
+
             $this->info( "Unlocked {$count} account(s)." );
 
             return self::SUCCESS;

--- a/src/Console/Commands/ManageAccountLockout.php
+++ b/src/Console/Commands/ManageAccountLockout.php
@@ -131,8 +131,21 @@ class ManageAccountLockout extends Command
         /** @var AccountLockoutManager $lockoutManager */
         $lockoutManager = App::make( AccountLockoutManager::class );
 
-        $reason   = $this->option( 'reason' ) ?? 'Locked via console command';
-        $duration = $this->option( 'permanent' ) ? null : (int) $this->option( 'duration' );
+        $reason    = $this->option( 'reason' ) ?? 'Locked via console command';
+        $permanent = (bool) $this->option( 'permanent' );
+
+        if ( $permanent ) {
+            $duration = null;
+        } else {
+            $duration = (int) $this->option( 'duration' );
+            if ( $duration <= 0 ) {
+                $this->error( '--duration must be a positive integer (or pass --permanent for an indefinite lockout).' );
+
+                return self::FAILURE;
+            }
+        }
+
+        $durationText = $permanent ? 'permanently' : "{$duration} minutes";
 
         if ( $userId = $this->option( 'user' ) ) {
             $user = $this->findUser( $userId );
@@ -141,7 +154,6 @@ class ManageAccountLockout extends Command
             }
 
             $lockoutManager->lockUser( $user, $duration, $reason );
-            $durationText = $duration ? "{$duration} minutes" : 'permanently';
             $this->info( "Locked account for user: {$user->email} ({$durationText})" );
 
             return self::SUCCESS;
@@ -149,7 +161,6 @@ class ManageAccountLockout extends Command
 
         if ( $ip = $this->option( 'ip' ) ) {
             $lockoutManager->lockIp( $ip, $duration, $reason );
-            $durationText = $duration ? "{$duration} minutes" : 'permanently';
             $this->info( "Locked IP address: {$ip} ({$durationText})" );
 
             return self::SUCCESS;
@@ -176,10 +187,10 @@ class ManageAccountLockout extends Command
         return $user;
     }
 
-    protected function invalidAction( string $action): int
+    protected function invalidAction( string $action ): int
     {
-        $this->error( "Invalid action: {$action}");
-        $this->line( 'Valid actions: list, unlock, lock');
+        $this->error( "Invalid action: {$action}" );
+        $this->line( 'Valid actions: list, unlock, lock' );
 
         return self::FAILURE;
     }

--- a/src/Contracts/AuthEventLoggerInterface.php
+++ b/src/Contracts/AuthEventLoggerInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Contracts;
+
+/**
+ * Minimal contract for logging authentication-related security events.
+ *
+ * Implementations live in downstream packages (e.g. `security-analytics`).
+ * security-auth treats this as an optional dependency — when an
+ * implementation is bound in the container, the package's middleware and
+ * services log through it; otherwise events are silently dropped.
+ *
+ * @since 1.0.0
+ */
+interface AuthEventLoggerInterface
+{
+    /**
+     * Log an authentication-related event with arbitrary contextual data.
+     *
+     * @param  string                $event    Short event name, e.g. `password_validation_failed`.
+     * @param  array<string, mixed>  $context  Event metadata.
+     */
+    public function authentication( string $event, array $context = [] ): void;
+}

--- a/src/Contracts/BreachCheckerInterface.php
+++ b/src/Contracts/BreachCheckerInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Contracts;
+
+interface BreachCheckerInterface
+{
+    /**
+     * Check if a password has been exposed in known data breaches.
+     *
+     * @param  string  $password  The plain-text password to check
+     *
+     * @return int Number of times password has been seen in breaches (0 if not found)
+     */
+    public function check( string $password ): int;
+
+    /**
+     * Check if password is compromised (boolean convenience method).
+     *
+     * @param  string  $password  The plain-text password to check
+     *
+     * @return bool True if password has been compromised
+     */
+    public function isCompromised( string $password ): bool;
+}

--- a/src/Contracts/PasswordSecurityServiceInterface.php
+++ b/src/Contracts/PasswordSecurityServiceInterface.php
@@ -1,0 +1,94 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Contracts;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+
+interface PasswordSecurityServiceInterface
+{
+    /**
+     * Validate a password against all configured policies.
+     *
+     * @param  string  $password  The plain-text password to validate
+     * @param  Authenticatable|null  $user  Optional user for context-aware validation
+     *
+     * @return array Array of error messages (empty if valid)
+     */
+    public function validatePassword( string $password, ?Authenticatable $user = null ): array;
+
+    /**
+     * Check if a password meets complexity requirements.
+     *
+     * @param  string  $password  The plain-text password to check
+     * @param  Authenticatable|null  $user  Optional user for context-aware validation
+     *
+     * @return array Array of error messages (empty if valid)
+     */
+    public function checkComplexity( string $password, ?Authenticatable $user = null ): array;
+
+    /**
+     * Check if password exists in user's history.
+     *
+     * @param  string  $password  The plain-text password to check
+     * @param  Authenticatable  $user  The user whose history to check
+     *
+     * @return bool True if password exists in history
+     */
+    public function isInHistory( string $password, Authenticatable $user ): bool;
+
+    /**
+     * Record a password in user's history.
+     *
+     * @param  string  $hashedPassword  The hashed password to record
+     * @param  Authenticatable  $user  The user to record for
+     */
+    public function recordPassword( string $hashedPassword, Authenticatable $user ): void;
+
+    /**
+     * Check if user's password has expired.
+     *
+     * @param  Authenticatable  $user  The user to check
+     *
+     * @return bool True if password has expired
+     */
+    public function isExpired( Authenticatable $user ): bool;
+
+    /**
+     * Get days until password expires.
+     *
+     * @param  Authenticatable  $user  The user to check
+     *
+     * @return int|null Days until expiration, null if no expiration
+     */
+    public function daysUntilExpiration( Authenticatable $user ): ?int;
+
+    /**
+     * Check if password has been compromised in known breaches.
+     *
+     * @param  string  $password  The plain-text password to check
+     *
+     * @return bool True if password has been compromised
+     */
+    public function isCompromised( string $password ): bool;
+
+    /**
+     * Calculate password strength score (0-4).
+     *
+     * @param  string  $password  The password to evaluate
+     * @param  array  $userInputs  Additional inputs to penalize (e.g., username, email)
+     *
+     * @return array Contains 'score', 'label', 'crackTime', and 'feedback'
+     */
+    public function calculateStrength( string $password, array $userInputs = [] ): array;
+
+    /**
+     * Prune old password history records.
+     *
+     * @param  Authenticatable  $user  The user whose history to prune
+     *
+     * @return int Number of records deleted
+     */
+    public function pruneHistory( Authenticatable $user): int;
+}

--- a/src/Events/AccountLocked.php
+++ b/src/Events/AccountLocked.php
@@ -1,0 +1,51 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Events;
+
+use ArtisanPackUI\SecurityAuth\Models\AccountLockout;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class AccountLocked
+{
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public AccountLockout $lockout,
+        public mixed $user = null,
+        public ?string $ipAddress = null,
+    ) {
+    }
+
+    /**
+     * Check if this is a permanent lockout.
+     */
+    public function isPermanent(): bool
+    {
+        return $this->lockout->isPermanent();
+    }
+
+    /**
+     * Get the lockout type.
+     */
+    public function getLockoutType(): string
+    {
+        return $this->lockout->lockout_type;
+    }
+
+    /**
+     * Get the reason for lockout.
+     */
+    public function getReason(): ?string
+    {
+        return $this->lockout->reason;
+    }
+}

--- a/src/Facades/TwoFactor.php
+++ b/src/Facades/TwoFactor.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * TwoFactor Facade
+ *
+ * Provides a static interface to the TwoFactorManager service.
+ *
+ * @link       https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-security
+ *
+ * @package    ArtisanPackUI\Security
+ * @subpackage ArtisanPackUI\Security\Facades
+ *
+ * @since      1.2.0
+ */
+
+namespace ArtisanPackUI\SecurityAuth\Facades;
+
+use ArtisanPackUI\SecurityAuth\TwoFactor\TwoFactorManager;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * Provides a static accessor to the TwoFactorManager.
+ *
+ * @since 1.2.0
+ *
+ * @method static void generateChallenge( Authenticatable $user )
+ * @method static bool verify( Authenticatable $user, string $code )
+ *
+ * @see   TwoFactorManager
+ */
+class TwoFactor extends Facade
+{
+	/**
+	 * Get the registered name of the component.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return string
+	 */
+	protected static function getFacadeAccessor(): string
+	{
+		return TwoFactorManager::class;
+	}
+}

--- a/src/Http/Middleware/CheckAccountLockout.php
+++ b/src/Http/Middleware/CheckAccountLockout.php
@@ -1,0 +1,109 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Http\Middleware;
+
+use ArtisanPackUI\SecurityAuth\Authentication\Lockout\AccountLockoutManager;
+use ArtisanPackUI\SecurityAuth\Models\AccountLockout;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckAccountLockout
+{
+    /**
+     * Create a new middleware instance.
+     */
+    public function __construct(
+        protected AccountLockoutManager $lockoutManager,
+    ) {
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle( Request $request, Closure $next ): Response
+    {
+        if ( ! config( 'artisanpack.security-auth.account_lockout.enabled', true ) ) {
+            return $next( $request );
+        }
+
+        $user = Auth::user();
+        $ip   = $request->ip();
+
+        // Check IP lockout
+        if ( $this->lockoutManager->isIpLocked( $ip ) ) {
+            $lockout = $this->lockoutManager->getIpLockout( $ip );
+
+            return $this->handleLockout( $request, $lockout, 'ip' );
+        }
+
+        // Check user lockout
+        if ( $user && $this->lockoutManager->isUserLocked( $user ) ) {
+            $lockout = $this->lockoutManager->getUserLockout( $user );
+
+            return $this->handleLockout( $request, $lockout, 'user' );
+        }
+
+        return $next( $request );
+    }
+
+    /**
+     * Handle a lockout response.
+     */
+    protected function handleLockout( Request $request, ?AccountLockout $lockout, string $type ): Response
+    {
+        if ( ! $lockout ) {
+            return response()->json( ['error' => 'Account is locked'], 423 );
+        }
+
+        $remainingSeconds = $this->lockoutManager->getRemainingLockoutDuration( $lockout );
+        $remainingMinutes = ceil( $remainingSeconds / 60 );
+
+        $message = match ( $lockout->lockout_type ) {
+            AccountLockout::TYPE_PERMANENT => 'Your account has been permanently locked. Please contact support.',
+            AccountLockout::TYPE_SOFT      => 'Additional verification is required to proceed.',
+            default                        => "Too many failed attempts. Please try again in {$remainingMinutes} minute(s).",
+        };
+
+        // For soft lockout, require CAPTCHA
+        if ( $lockout->isSoft() ) {
+            session( ['require_captcha' => true, 'lockout_id' => $lockout->id] );
+
+            if ( $request->expectsJson() ) {
+                return response()->json( [
+                    'error'           => $message,
+                    'require_captcha' => true,
+                    'lockout_type'    => $lockout->lockout_type,
+                ], 423 );
+            }
+
+            // Continue but with CAPTCHA requirement
+            return redirect()->back()
+                ->with( 'warning', 'Please complete the CAPTCHA to continue.' );
+        }
+
+        // Log out user if they're logged in
+        if ( Auth::check() && 'user' === $type ) {
+            Auth::logout();
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+        }
+
+        if ( $request->expectsJson() ) {
+            return response()->json( [
+                'error'             => $message,
+                'lockout_type'      => $lockout->lockout_type,
+                'remaining_seconds' => $remainingSeconds,
+                'reason'            => $lockout->reason,
+            ], 423 );
+        }
+
+        return redirect()->route( 'login')
+            ->with( 'error', $message);
+    }
+}

--- a/src/Http/Middleware/CheckAccountLockout.php
+++ b/src/Http/Middleware/CheckAccountLockout.php
@@ -9,6 +9,7 @@ use ArtisanPackUI\SecurityAuth\Models\AccountLockout;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
 use Symfony\Component\HttpFoundation\Response;
 
 class CheckAccountLockout
@@ -103,7 +104,10 @@ class CheckAccountLockout
             ], 423 );
         }
 
-        return redirect()->route( 'login')
-            ->with( 'error', $message);
+        $redirect = Route::has( 'login' )
+            ? redirect()->route( 'login' )
+            : redirect()->to( url( '/' ) );
+
+        return $redirect->with( 'error', $message );
     }
 }

--- a/src/Http/Middleware/EnforcePasswordPolicy.php
+++ b/src/Http/Middleware/EnforcePasswordPolicy.php
@@ -49,7 +49,7 @@ class EnforcePasswordPolicy
 
         $password = $request->input( 'password' );
 
-        if ( null === $password ) {
+        if ( ! is_string( $password ) ) {
             return $next( $request );
         }
 
@@ -87,6 +87,6 @@ class EnforcePasswordPolicy
             'user_id' => $request->user()?->id,
             'route'   => $request->route()?->getName(),
             'errors'  => $errors,
-        ]);
+        ] );
     }
 }

--- a/src/Http/Middleware/EnforcePasswordPolicy.php
+++ b/src/Http/Middleware/EnforcePasswordPolicy.php
@@ -1,0 +1,92 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Http\Middleware;
+
+use ArtisanPackUI\SecurityAuth\Contracts\AuthEventLoggerInterface;
+use ArtisanPackUI\SecurityAuth\Contracts\PasswordSecurityServiceInterface;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnforcePasswordPolicy
+{
+    /**
+     * The password security service.
+     */
+    protected PasswordSecurityServiceInterface $passwordService;
+
+    /**
+     * The security event logger.
+     */
+    protected ?AuthEventLoggerInterface $logger;
+
+    /**
+     * Create a new middleware instance.
+     */
+    public function __construct(
+        PasswordSecurityServiceInterface $passwordService,
+        ?AuthEventLoggerInterface $logger = null,
+    ) {
+        $this->passwordService = $passwordService;
+        $this->logger          = $logger;
+    }
+
+    /**
+     * Handle password validation on registration/password change routes.
+     */
+    public function handle( Request $request, Closure $next ): Response
+    {
+        if ( ! config( 'artisanpack.security-auth.passwordSecurity.enabled', true ) ) {
+            return $next( $request );
+        }
+
+        // Only validate on POST/PUT/PATCH requests with password field
+        if ( ! in_array( $request->method(), ['POST', 'PUT', 'PATCH'], true ) ) {
+            return $next( $request );
+        }
+
+        $password = $request->input( 'password' );
+
+        if ( null === $password ) {
+            return $next( $request );
+        }
+
+        $user   = $request->user();
+        $errors = $this->passwordService->validatePassword( $password, $user );
+
+        if ( ! empty( $errors ) ) {
+            $this->logValidationFailure( $request, $errors );
+
+            if ( $request->expectsJson() ) {
+                return response()->json( [
+                    'message' => 'Password does not meet security requirements.',
+                    'errors'  => ['password' => $errors],
+                ], 422 );
+            }
+
+            return back()
+                ->withInput( $request->except( 'password', 'password_confirmation' ) )
+                ->withErrors( ['password' => $errors] );
+        }
+
+        return $next( $request );
+    }
+
+    /**
+     * Log a validation failure event.
+     */
+    protected function logValidationFailure( Request $request, array $errors ): void
+    {
+        if ( ! config( 'artisanpack.security-auth.passwordSecurity.logging.failedValidations', true ) ) {
+            return;
+        }
+
+        $this->logger?->authentication( 'password_validation_failed', [
+            'user_id' => $request->user()?->id,
+            'route'   => $request->route()?->getName(),
+            'errors'  => $errors,
+        ]);
+    }
+}

--- a/src/Http/Middleware/StepUpAuthentication.php
+++ b/src/Http/Middleware/StepUpAuthentication.php
@@ -1,0 +1,131 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class StepUpAuthentication
+{
+    /**
+     * The timeout for step-up authentication in minutes.
+     */
+    protected int $stepUpTimeout;
+
+    /**
+     * Create a new middleware instance.
+     */
+    public function __construct()
+    {
+        $this->stepUpTimeout = config( 'artisanpack.security-auth.step_up_authentication.timeout_minutes', 15 );
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle( Request $request, Closure $next, ?string $method = null ): Response
+    {
+        $user = Auth::user();
+        if ( ! $user ) {
+            if ( $request->expectsJson() ) {
+                return response()->json( ['error' => 'Unauthorized'], 401 );
+            }
+
+            return $this->redirectTo( 'login' );
+        }
+
+        // Check if step-up authentication is recent enough
+        $lastStepUp = session( 'step_up_authenticated_at' );
+
+        if ( ! $lastStepUp || now()->diffInMinutes( $lastStepUp ) > $this->stepUpTimeout ) {
+            // Require step-up authentication
+            session( ['step_up_intended_url' => $request->url()] );
+
+            if ( $request->expectsJson() ) {
+                return response()->json( [
+                    'error'           => 'Step-up authentication required',
+                    'require_step_up' => true,
+                    'methods'         => $this->getAvailableMethods( $user, $method ),
+                ], 401 );
+            }
+
+            return $this->redirectTo( 'password.confirm' )
+                ->with( 'warning', 'Please confirm your identity to continue.' );
+        }
+
+        return $next( $request );
+    }
+
+    /**
+     * Mark step-up authentication as complete.
+     */
+    public static function complete(): void
+    {
+        session( ['step_up_authenticated_at' => now()] );
+    }
+
+    /**
+     * Clear step-up authentication.
+     */
+    public static function clear(): void
+    {
+        session()->forget( ['step_up_authenticated_at', 'step_up_intended_url'] );
+    }
+
+    /**
+     * Redirect to a route, falling back to a URL if the route doesn't exist.
+     */
+    protected function redirectTo( string $routeName ): \Illuminate\Http\RedirectResponse
+    {
+        $configRoute = config( "artisanpack.security-auth.step_up_authentication.routes.{$routeName}" );
+
+        if ( $configRoute ) {
+            return redirect( $configRoute );
+        }
+
+        if ( \Illuminate\Support\Facades\Route::has( $routeName ) ) {
+            return redirect()->route( $routeName );
+        }
+
+        // Fallback to home or return a response
+        return redirect( '/' );
+    }
+
+    /**
+     * Get available step-up authentication methods.
+     *
+     * @return array<string>
+     */
+    protected function getAvailableMethods( mixed $user, ?string $requiredMethod ): array
+    {
+        $methods = ['password'];
+
+        // Check if user has 2FA enabled
+        if ( method_exists( $user, 'hasTwoFactorEnabled' ) && $user->hasTwoFactorEnabled() ) {
+            $methods[] = '2fa';
+        }
+
+        // Check if user has WebAuthn credentials
+        if ( method_exists( $user, 'hasWebAuthnCredentials' ) && $user->hasWebAuthnCredentials() ) {
+            $methods[] = 'webauthn';
+        }
+
+        // Check if user has biometric
+        if ( method_exists( $user, 'hasPlatformAuthenticators' ) && $user->hasPlatformAuthenticators() ) {
+            $methods[] = 'biometric';
+        }
+
+        // If a specific method is required, filter
+        if ( $requiredMethod ) {
+            $methods = in_array( $requiredMethod, $methods) ? [$requiredMethod] : [];
+        }
+
+        return $methods;
+    }
+}

--- a/src/Http/Middleware/StepUpAuthentication.php
+++ b/src/Http/Middleware/StepUpAuthentication.php
@@ -45,7 +45,7 @@ class StepUpAuthentication
 
         if ( ! $lastStepUp || now()->diffInMinutes( $lastStepUp ) > $this->stepUpTimeout ) {
             // Require step-up authentication
-            session( ['step_up_intended_url' => $request->url()] );
+            session( ['step_up_intended_url' => $request->fullUrl()] );
 
             if ( $request->expectsJson() ) {
                 return response()->json( [
@@ -123,7 +123,7 @@ class StepUpAuthentication
 
         // If a specific method is required, filter
         if ( $requiredMethod ) {
-            $methods = in_array( $requiredMethod, $methods) ? [$requiredMethod] : [];
+            $methods = in_array( $requiredMethod, $methods ) ? [$requiredMethod] : [];
         }
 
         return $methods;

--- a/src/Http/Middleware/TwoFactorMiddleware.php
+++ b/src/Http/Middleware/TwoFactorMiddleware.php
@@ -50,15 +50,18 @@ class TwoFactorMiddleware
 	 */
 	public function handle( Request $request, Closure $next ): mixed
 	{
-		$user = $request->user();
+		$user            = $request->user();
+		$verifyRouteName = config( 'artisanpack.security-auth.routes.verify' );
 
 		if (
 			$user &&
 			method_exists( $user, 'hasTwoFactorEnabled' ) &&
 			$user->hasTwoFactorEnabled() &&
-			! $request->session()->get( self::SESSION_KEY )
+			! $request->session()->get( self::SESSION_KEY ) &&
+			$verifyRouteName &&
+			! $request->routeIs( $verifyRouteName )
 		) {
-			return redirect()->route( config( 'artisanpack.security-auth.routes.verify' ) );
+			return redirect()->route( $verifyRouteName );
 		}
 
 		return $next( $request );

--- a/src/Http/Middleware/TwoFactorMiddleware.php
+++ b/src/Http/Middleware/TwoFactorMiddleware.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Two-Factor Authentication Middleware
+ *
+ * Intercepts requests for authenticated users with 2FA enabled to ensure
+ * they have completed the verification step.
+ *
+ * @link       https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-security
+ *
+ * @package    ArtisanPackUI\Security
+ * @subpackage ArtisanPackUI\Security\Http\Middleware
+ *
+ * @since      1.2.0
+ */
+
+namespace ArtisanPackUI\SecurityAuth\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+/**
+ * Ensures a user has completed the two-factor authentication challenge.
+ *
+ * @since 1.2.0
+ */
+class TwoFactorMiddleware
+{
+	/**
+	 * The session key for tracking 2FA verification status.
+	 *
+	 * This key is used to store a boolean value in the session to indicate
+	 * that the user has successfully passed the two-factor challenge.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var string
+	 */
+	public const SESSION_KEY = 'two_factor_verified';
+
+	/**
+	 * Handle an incoming request.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param Request $request The incoming request.
+	 * @param Closure $next    The next middleware in the chain.
+	 *
+	 * @return mixed
+	 */
+	public function handle( Request $request, Closure $next ): mixed
+	{
+		$user = $request->user();
+
+		if (
+			$user &&
+			method_exists( $user, 'hasTwoFactorEnabled' ) &&
+			$user->hasTwoFactorEnabled() &&
+			! $request->session()->get( self::SESSION_KEY )
+		) {
+			return redirect()->route( config( 'artisanpack.security-auth.routes.verify' ) );
+		}
+
+		return $next( $request );
+	}
+}

--- a/src/Livewire/AccountLockoutStatus.php
+++ b/src/Livewire/AccountLockoutStatus.php
@@ -70,7 +70,7 @@ class AccountLockoutStatus extends Component
 
     public function render()
     {
-        return view( 'security::livewire.account-lockout-status', [
+        return view( 'security-auth::livewire.account-lockout-status', [
             'lockoutHistory' => $this->lockoutHistory,
         ] );
     }

--- a/src/Livewire/AccountLockoutStatus.php
+++ b/src/Livewire/AccountLockoutStatus.php
@@ -1,0 +1,88 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Livewire;
+
+use ArtisanPackUI\SecurityAuth\Authentication\Lockout\AccountLockoutManager;
+use ArtisanPackUI\SecurityAuth\Models\AccountLockout;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+class AccountLockoutStatus extends Component
+{
+    use WithPagination;
+
+    public ?array $currentLockout = null;
+
+    public int $perPage = 10;
+
+    protected AccountLockoutManager $lockoutManager;
+
+    public function boot( AccountLockoutManager $lockoutManager ): void
+    {
+        $this->lockoutManager = $lockoutManager;
+    }
+
+    public function mount(): void
+    {
+        $this->loadCurrentLockout();
+    }
+
+    public function loadCurrentLockout(): void
+    {
+        $user = Auth::user();
+
+        if ( ! $user ) {
+            return;
+        }
+
+        $lockout = $this->lockoutManager->getUserLockout( $user );
+
+        if ( $lockout && $lockout->isActive() ) {
+            $this->currentLockout = [
+                'id'                => $lockout->id,
+                'type'              => $lockout->lockout_type,
+                'type_label'        => $this->getLockoutTypeLabel( $lockout->lockout_type ),
+                'reason'            => $lockout->reason,
+                'expires_at'        => $lockout->expires_at?->format( 'M j, Y g:i A' ),
+                'remaining_minutes' => $lockout->expires_at ? ceil( now()->diffInMinutes( $lockout->expires_at, false ) ) : null,
+                'is_permanent'      => $lockout->isPermanent(),
+            ];
+        } else {
+            $this->currentLockout = null;
+        }
+    }
+
+    public function getLockoutHistoryProperty()
+    {
+        $user = Auth::user();
+
+        if ( ! $user ) {
+            return collect();
+        }
+
+        return AccountLockout::where( 'user_id', $user->id )
+            ->orderBy( 'created_at', 'desc' )
+            ->paginate( $this->perPage );
+    }
+
+    public function render()
+    {
+        return view( 'security::livewire.account-lockout-status', [
+            'lockoutHistory' => $this->lockoutHistory,
+        ] );
+    }
+
+    protected function getLockoutTypeLabel( string $type ): string
+    {
+        return match ( $type ) {
+            AccountLockout::TYPE_TEMPORARY   => 'Temporary Lockout',
+            AccountLockout::TYPE_PROGRESSIVE => 'Progressive Lockout',
+            AccountLockout::TYPE_PERMANENT   => 'Permanent Lockout',
+            AccountLockout::TYPE_SOFT        => 'Soft Lockout (CAPTCHA Required)',
+            default                          => 'Unknown',
+        };
+    }
+}

--- a/src/Livewire/PasswordStrengthMeter.php
+++ b/src/Livewire/PasswordStrengthMeter.php
@@ -1,0 +1,205 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Livewire;
+
+use ArtisanPackUI\SecurityAuth\Contracts\PasswordSecurityServiceInterface;
+use Livewire\Attributes\Reactive;
+use Livewire\Component;
+
+class PasswordStrengthMeter extends Component
+{
+    /**
+     * The password to evaluate.
+     */
+    #[Reactive]
+    public string $password = '';
+
+    /**
+     * Additional user inputs to penalize in strength calculation.
+     *
+     * @var array<int, string>
+     */
+    public array $userInputs = [];
+
+    /**
+     * The calculated strength score (0-4).
+     */
+    public int $score = 0;
+
+    /**
+     * The strength label.
+     */
+    public string $label = '';
+
+    /**
+     * The estimated crack time.
+     */
+    public string $crackTime = '';
+
+    /**
+     * Feedback suggestions for improving the password.
+     *
+     * @var array<int, string>
+     */
+    public array $feedback = [];
+
+    /**
+     * Password requirements and their met status.
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    public array $requirements = [];
+
+    /**
+     * Mount the component.
+     *
+     * @param  array<int, string>  $userInputs
+     */
+    public function mount( array $userInputs = [] ): void
+    {
+        $this->userInputs = $userInputs;
+        $this->initializeRequirements();
+    }
+
+    /**
+     * Handle password updates.
+     */
+    public function updatedPassword(): void
+    {
+        if ( empty( $this->password ) ) {
+            $this->resetMetrics();
+
+            return;
+        }
+
+        $service = app( PasswordSecurityServiceInterface::class );
+        $result  = $service->calculateStrength( $this->password, $this->userInputs );
+
+        $this->score     = $result['score'];
+        $this->label     = $result['label'];
+        $this->crackTime = $result['crackTime'] ?? '';
+        $this->feedback  = $result['feedback'] ?? [];
+
+        // Update requirements status
+        $this->updateRequirements();
+    }
+
+    /**
+     * Get the badge color based on the score.
+     */
+    public function getBadgeColor(): string
+    {
+        return match ( $this->score ) {
+            0       => 'error',
+            1       => 'error',
+            2       => 'warning',
+            3       => 'info',
+            4       => 'success',
+            default => 'secondary',
+        };
+    }
+
+    /**
+     * Get the progress bar color based on the score.
+     */
+    public function getProgressColor(): string
+    {
+        return match ( $this->score ) {
+            0       => 'error',
+            1       => 'error',
+            2       => 'warning',
+            3       => 'info',
+            4       => 'success',
+            default => 'secondary',
+        };
+    }
+
+    /**
+     * Get the progress bar width based on the score.
+     */
+    public function getBarWidth(): int
+    {
+        return match ( $this->score ) {
+            0       => 5,
+            1       => 25,
+            2       => 50,
+            3       => 75,
+            4       => 100,
+            default => 0,
+        };
+    }
+
+    /**
+     * Render the component.
+     *
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function render()
+    {
+        return view( 'security::livewire.password-strength-meter' );
+    }
+
+    /**
+     * Initialize the requirements checklist.
+     */
+    protected function initializeRequirements(): void
+    {
+        $config = config( 'artisanpack.security-auth.passwordSecurity.complexity', [] );
+
+        $this->requirements = [
+            'length' => [
+                'label'   => sprintf( 'At least %d characters', $config['minLength'] ?? 8 ),
+                'met'     => false,
+                'enabled' => true,
+            ],
+            'uppercase' => [
+                'label'   => 'Contains uppercase letter',
+                'met'     => false,
+                'enabled' => $config['requireUppercase'] ?? true,
+            ],
+            'lowercase' => [
+                'label'   => 'Contains lowercase letter',
+                'met'     => false,
+                'enabled' => $config['requireLowercase'] ?? true,
+            ],
+            'number' => [
+                'label'   => 'Contains number',
+                'met'     => false,
+                'enabled' => $config['requireNumbers'] ?? true,
+            ],
+            'symbol' => [
+                'label'   => 'Contains special character',
+                'met'     => false,
+                'enabled' => $config['requireSymbols'] ?? true,
+            ],
+        ];
+    }
+
+    /**
+     * Update the requirements based on the current password.
+     */
+    protected function updateRequirements(): void
+    {
+        $config = config( 'artisanpack.security-auth.passwordSecurity.complexity', [] );
+
+        $this->requirements['length']['met']    = strlen( $this->password ) >= ( $config['minLength'] ?? 8 );
+        $this->requirements['uppercase']['met'] = (bool) preg_match( '/[A-Z]/', $this->password );
+        $this->requirements['lowercase']['met'] = (bool) preg_match( '/[a-z]/', $this->password );
+        $this->requirements['number']['met']    = (bool) preg_match( '/[0-9]/', $this->password );
+        $this->requirements['symbol']['met']    = (bool) preg_match( '/[^A-Za-z0-9]/', $this->password );
+    }
+
+    /**
+     * Reset all metrics to their initial state.
+     */
+    protected function resetMetrics(): void
+    {
+        $this->score     = 0;
+        $this->label     = '';
+        $this->crackTime = '';
+        $this->feedback  = [];
+        $this->initializeRequirements();
+    }
+}

--- a/src/Livewire/PasswordStrengthMeter.php
+++ b/src/Livewire/PasswordStrengthMeter.php
@@ -68,7 +68,8 @@ class PasswordStrengthMeter extends Component
      */
     public function updatedPassword(): void
     {
-        if ( empty( $this->password ) ) {
+        // Use a strict empty-string check so values like "0" still get scored.
+        if ( '' === $this->password ) {
             $this->resetMetrics();
 
             return;
@@ -138,7 +139,7 @@ class PasswordStrengthMeter extends Component
      */
     public function render()
     {
-        return view( 'security::livewire.password-strength-meter' );
+        return view( 'security-auth::livewire.password-strength-meter' );
     }
 
     /**

--- a/src/Livewire/SessionManager.php
+++ b/src/Livewire/SessionManager.php
@@ -7,6 +7,7 @@ namespace ArtisanPackUI\SecurityAuth\Livewire;
 use ArtisanPackUI\SecurityAuth\Authentication\Session\AdvancedSessionManager;
 use Exception;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Livewire\Component;
 
 class SessionManager extends Component
@@ -92,7 +93,11 @@ class SessionManager extends Component
             session()->flash( 'success', 'Session has been terminated.' );
             $this->loadSessions();
         } catch ( Exception $e ) {
-            session()->flash( 'error', 'Failed to terminate session: ' . $e->getMessage() );
+            Log::error( 'SessionManager::terminateSession failed', [
+                'session_id' => $sessionId,
+                'exception'  => $e,
+            ] );
+            session()->flash( 'error', 'Failed to terminate session. Please try again.' );
         }
 
         $this->terminatingSessionId = null;
@@ -115,13 +120,16 @@ class SessionManager extends Component
             session()->flash( 'success', "{$count} session(s) have been terminated." );
             $this->loadSessions();
         } catch ( Exception $e ) {
-            session()->flash( 'error', 'Failed to terminate sessions: ' . $e->getMessage() );
+            Log::error( 'SessionManager::terminateAllOtherSessions failed', [
+                'exception' => $e,
+            ] );
+            session()->flash( 'error', 'Failed to terminate sessions. Please try again.' );
         }
     }
 
     public function render()
     {
-        return view( 'security::livewire.session-manager' );
+        return view( 'security-auth::livewire.session-manager' );
     }
 
     protected function getDeviceIcon( string $deviceType ): string
@@ -140,8 +148,8 @@ class SessionManager extends Component
             $session->city,
             $session->region,
             $session->country,
-        ]);
+        ] );
 
-        return implode( ', ', $parts) ?: 'Unknown location';
+        return implode( ', ', $parts ) ?: 'Unknown location';
     }
 }

--- a/src/Livewire/SessionManager.php
+++ b/src/Livewire/SessionManager.php
@@ -1,0 +1,147 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Livewire;
+
+use ArtisanPackUI\SecurityAuth\Authentication\Session\AdvancedSessionManager;
+use Exception;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Component;
+
+class SessionManager extends Component
+{
+    public array $sessions = [];
+
+    public ?string $currentSessionId = null;
+
+    public ?string $terminatingSessionId = null;
+
+    protected AdvancedSessionManager $sessionManager;
+
+    public function boot( AdvancedSessionManager $sessionManager ): void
+    {
+        $this->sessionManager = $sessionManager;
+    }
+
+    public function mount(): void
+    {
+        $this->loadSessions();
+    }
+
+    public function loadSessions(): void
+    {
+        $user = Auth::user();
+
+        if ( ! $user || ! method_exists( $user, 'userSessions' ) ) {
+            return;
+        }
+
+        $currentSessionToken = session( 'user_session_token' );
+
+        $this->sessions = $user->userSessions()
+            ->active()
+            ->orderBy( 'last_activity_at', 'desc' )
+            ->get()
+            ->map( function ( $session ) use ( $currentSessionToken ) {
+                $isCurrent = $session->session_token === $currentSessionToken;
+
+                if ( $isCurrent ) {
+                    $this->currentSessionId = $session->id;
+                }
+
+                return [
+                    'id'            => $session->id,
+                    'ip_address'    => $session->ip_address,
+                    'browser'       => $session->browser ?? 'Unknown',
+                    'platform'      => $session->platform ?? 'Unknown',
+                    'device_type'   => $session->device_type ?? 'desktop',
+                    'device_icon'   => $this->getDeviceIcon( $session->device_type ?? 'desktop' ),
+                    'location'      => $this->formatLocation( $session ),
+                    'is_current'    => $isCurrent,
+                    'started_at'    => $session->created_at->format( 'M j, Y g:i A' ),
+                    'last_activity' => $session->last_activity_at?->diffForHumans() ?? 'Unknown',
+                    'expires_at'    => $session->expires_at?->format( 'M j, Y g:i A' ),
+                ];
+            } )
+            ->toArray();
+    }
+
+    public function confirmTerminate( string $sessionId ): void
+    {
+        $this->terminatingSessionId = $sessionId;
+    }
+
+    public function cancelTerminate(): void
+    {
+        $this->terminatingSessionId = null;
+    }
+
+    public function terminateSession( string $sessionId ): void
+    {
+        // Prevent terminating current session from here
+        if ( $sessionId === $this->currentSessionId ) {
+            session()->flash( 'error', 'Use the logout function to end your current session.' );
+            $this->terminatingSessionId = null;
+
+            return;
+        }
+
+        try {
+            $this->sessionManager->terminateSession( $sessionId );
+            session()->flash( 'success', 'Session has been terminated.' );
+            $this->loadSessions();
+        } catch ( Exception $e ) {
+            session()->flash( 'error', 'Failed to terminate session: ' . $e->getMessage() );
+        }
+
+        $this->terminatingSessionId = null;
+    }
+
+    public function terminateAllOtherSessions(): void
+    {
+        $user = Auth::user();
+
+        if ( ! $user ) {
+            return;
+        }
+
+        try {
+            $count = $this->sessionManager->terminateAllUserSessions(
+                $user,
+                except: $this->currentSessionId,
+            );
+
+            session()->flash( 'success', "{$count} session(s) have been terminated." );
+            $this->loadSessions();
+        } catch ( Exception $e ) {
+            session()->flash( 'error', 'Failed to terminate sessions: ' . $e->getMessage() );
+        }
+    }
+
+    public function render()
+    {
+        return view( 'security::livewire.session-manager' );
+    }
+
+    protected function getDeviceIcon( string $deviceType ): string
+    {
+        return match ( $deviceType ) {
+            'desktop' => 'fas fa-desktop',
+            'mobile'  => 'fas fa-mobile-alt',
+            'tablet'  => 'fas fa-tablet-alt',
+            default   => 'fas fa-globe',
+        };
+    }
+
+    protected function formatLocation( $session ): string
+    {
+        $parts = array_filter( [
+            $session->city,
+            $session->region,
+            $session->country,
+        ]);
+
+        return implode( ', ', $parts) ?: 'Unknown location';
+    }
+}

--- a/src/Livewire/StepUpAuthenticationModal.php
+++ b/src/Livewire/StepUpAuthenticationModal.php
@@ -1,0 +1,185 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Livewire;
+
+use ArtisanPackUI\SecurityAuth\Http\Middleware\StepUpAuthentication;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+class StepUpAuthenticationModal extends Component
+{
+    public bool $show = false;
+
+    public string $method = 'password';
+
+    public string $password = '';
+
+    public string $code = '';
+
+    public array $availableMethods = [];
+
+    public ?string $redirectUrl = null;
+
+    public ?string $error = null;
+
+    public function mount(): void
+    {
+        $this->loadAvailableMethods();
+    }
+
+    #[On( 'step-up-required' )]
+    public function openModal( ?string $redirectUrl = null ): void
+    {
+        $this->redirectUrl = $redirectUrl ?? session( 'step_up_intended_url' );
+        $this->loadAvailableMethods();
+        $this->reset( ['password', 'code', 'error'] );
+        $this->show = true;
+    }
+
+    public function closeModal(): void
+    {
+        $this->show = false;
+        $this->reset( ['password', 'code', 'error'] );
+    }
+
+    public function loadAvailableMethods(): void
+    {
+        $user = Auth::user();
+
+        if ( ! $user ) {
+            return;
+        }
+
+        $this->availableMethods = ['password'];
+
+        if ( method_exists( $user, 'hasTwoFactorEnabled' ) && $user->hasTwoFactorEnabled() ) {
+            $this->availableMethods[] = '2fa';
+        }
+
+        if ( method_exists( $user, 'hasWebAuthnCredentials' ) && $user->hasWebAuthnCredentials() ) {
+            $this->availableMethods[] = 'webauthn';
+        }
+
+        if ( method_exists( $user, 'hasPlatformAuthenticators' ) && $user->hasPlatformAuthenticators() ) {
+            $this->availableMethods[] = 'biometric';
+        }
+
+        // Default to first available method
+        if ( ! in_array( $this->method, $this->availableMethods ) ) {
+            $this->method = $this->availableMethods[0] ?? 'password';
+        }
+    }
+
+    public function verifyPassword(): void
+    {
+        $this->validate( [
+            'password' => 'required|string',
+        ] );
+
+        $user = Auth::user();
+
+        if ( ! $user ) {
+            $this->error = 'You must be logged in.';
+
+            return;
+        }
+
+        if ( ! Hash::check( $this->password, $user->password ) ) {
+            $this->error    = 'Invalid password.';
+            $this->password = '';
+
+            return;
+        }
+
+        $this->completeStepUp();
+    }
+
+    public function verify2fa(): void
+    {
+        $this->validate( [
+            'code' => 'required|string|size:6',
+        ] );
+
+        $user = Auth::user();
+
+        if ( ! $user ) {
+            $this->error = 'You must be logged in.';
+
+            return;
+        }
+
+        // Use the TwoFactorService if available
+        if ( method_exists( $user, 'validateTwoFactorCode' ) ) {
+            if ( ! $user->validateTwoFactorCode( $this->code ) ) {
+                $this->error = 'Invalid verification code.';
+                $this->code  = '';
+
+                return;
+            }
+        } else {
+            $this->error = 'Two-factor authentication is not configured.';
+            $this->code  = '';
+            return;
+        }
+
+        $this->completeStepUp();
+    }
+
+    #[On( 'webauthn-step-up-complete' )]
+    public function verifyWebAuthn( array $response ): void
+    {
+        // WebAuthn verification handled by the event
+        $this->completeStepUp();
+    }
+
+    #[On( 'biometric-step-up-complete' )]
+    public function verifyBiometric( array $response ): void
+    {
+        // Biometric verification handled by the event
+        $this->completeStepUp();
+    }
+
+    public function getMethodLabel( string $method ): string
+    {
+        return match ( $method ) {
+            'password'  => 'Password',
+            '2fa'       => 'Authenticator App',
+            'webauthn'  => 'Security Key',
+            'biometric' => 'Biometric',
+            default     => ucfirst( $method ),
+        };
+    }
+
+    public function getMethodIcon( string $method ): string
+    {
+        return match ( $method ) {
+            'password'  => 'fas fa-key',
+            '2fa'       => 'fas fa-mobile-alt',
+            'webauthn'  => 'fas fa-usb',
+            'biometric' => 'fas fa-fingerprint',
+            default     => 'fas fa-shield-alt',
+        };
+    }
+
+    public function render()
+    {
+        return view( 'security::livewire.step-up-authentication-modal' );
+    }
+
+    protected function completeStepUp(): void
+    {
+        StepUpAuthentication::complete();
+
+        $this->show = false;
+
+        if ( $this->redirectUrl ) {
+            $this->redirect( $this->redirectUrl);
+        } else {
+            $this->dispatch( 'step-up-complete');
+        }
+    }
+}

--- a/src/Livewire/StepUpAuthenticationModal.php
+++ b/src/Livewire/StepUpAuthenticationModal.php
@@ -34,7 +34,7 @@ class StepUpAuthenticationModal extends Component
     #[On( 'step-up-required' )]
     public function openModal( ?string $redirectUrl = null ): void
     {
-        $this->redirectUrl = $redirectUrl ?? session( 'step_up_intended_url' );
+        $this->redirectUrl = $this->safeRedirect( $redirectUrl ?? session( 'step_up_intended_url' ) );
         $this->loadAvailableMethods();
         $this->reset( ['password', 'code', 'error'] );
         $this->show = true;
@@ -132,15 +132,20 @@ class StepUpAuthenticationModal extends Component
     #[On( 'webauthn-step-up-complete' )]
     public function verifyWebAuthn( array $response ): void
     {
-        // WebAuthn verification handled by the event
-        $this->completeStepUp();
+        // Server-side WebAuthn assertion verification lives in
+        // artisanpack-ui/security-advanced-auth. Until an app wires its own
+        // verifier into this dispatch, refuse to complete the step-up so a
+        // crafted Livewire event can't satisfy the gate by itself.
+        $this->error = 'WebAuthn verification is not wired up on this server.';
     }
 
     #[On( 'biometric-step-up-complete' )]
     public function verifyBiometric( array $response ): void
     {
-        // Biometric verification handled by the event
-        $this->completeStepUp();
+        // Same reasoning as verifyWebAuthn — biometric verification belongs
+        // to security-advanced-auth and must be performed server-side before
+        // the step-up gate is released.
+        $this->error = 'Biometric verification is not wired up on this server.';
     }
 
     public function getMethodLabel( string $method ): string
@@ -167,7 +172,7 @@ class StepUpAuthenticationModal extends Component
 
     public function render()
     {
-        return view( 'security::livewire.step-up-authentication-modal' );
+        return view( 'security-auth::livewire.step-up-authentication-modal' );
     }
 
     protected function completeStepUp(): void
@@ -177,9 +182,33 @@ class StepUpAuthenticationModal extends Component
         $this->show = false;
 
         if ( $this->redirectUrl ) {
-            $this->redirect( $this->redirectUrl);
+            $this->redirect( $this->redirectUrl );
         } else {
-            $this->dispatch( 'step-up-complete');
+            $this->dispatch( 'step-up-complete' );
         }
+    }
+
+    /**
+     * Whitelist redirect targets to internal paths or same-host URLs to avoid
+     * an open-redirect via the Livewire event payload.
+     */
+    protected function safeRedirect( ?string $url ): ?string
+    {
+        if ( null === $url || '' === $url ) {
+            return null;
+        }
+
+        if ( str_starts_with( $url, '/' ) && ! str_starts_with( $url, '//' ) ) {
+            return $url;
+        }
+
+        $parsed = parse_url( $url );
+        $appUrl = parse_url( (string) config( 'app.url' ) );
+
+        if ( ! $parsed || empty( $parsed['host'] ) || empty( $appUrl['host'] ?? null ) ) {
+            return null;
+        }
+
+        return $parsed['host'] === $appUrl['host'] ? $url : null;
     }
 }

--- a/src/Mail/TwoFactorCodeMailable.php
+++ b/src/Mail/TwoFactorCodeMailable.php
@@ -34,18 +34,18 @@ class TwoFactorCodeMailable extends Mailable
 	 *
 	 * @since 1.2.0
 	 *
-	 * @var int
+	 * @var string
 	 */
-	protected int $code;
+	protected string $code;
 
 	/**
 	 * Create a new message instance.
 	 *
 	 * @since 1.2.0
 	 *
-	 * @param int $code The 2FA code.
+	 * @param string $code The 2FA code (kept as a string so leading zeros survive).
 	 */
-	public function __construct( int $code )
+	public function __construct( string $code )
 	{
 		$this->code = $code;
 	}

--- a/src/Mail/TwoFactorCodeMailable.php
+++ b/src/Mail/TwoFactorCodeMailable.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Two-Factor Code Mailable
+ *
+ * Defines the email sent to users containing their two-factor authentication code.
+ *
+ * @link       https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-security
+ *
+ * @package    ArtisanPackUI\Security
+ * @subpackage ArtisanPackUI\Security\Mail
+ *
+ * @since      1.2.0
+ */
+
+namespace ArtisanPackUI\SecurityAuth\Mail;
+
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Defines the 2FA code email.
+ *
+ * @since 1.2.0
+ */
+class TwoFactorCodeMailable extends Mailable
+{
+	use SerializesModels;
+
+	/**
+	 * The two-factor authentication code.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var int
+	 */
+	protected int $code;
+
+	/**
+	 * Create a new message instance.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param int $code The 2FA code.
+	 */
+	public function __construct( int $code )
+	{
+		$this->code = $code;
+	}
+
+	/**
+	 * Get the message envelope.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return Envelope
+	 */
+	public function envelope(): Envelope
+	{
+		return new Envelope(
+			subject: 'Your Two-Factor Authentication Code',
+		);
+	}
+
+	/**
+	 * Get the message content definition.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return Content
+	 */
+	public function content(): Content
+	{
+		return new Content(
+			markdown: 'artisanpack-ui-security::emails.two-factor-code',
+			with:     [
+						  'code' => $this->code,
+					  ],
+		);
+	}
+}

--- a/src/Mail/TwoFactorCodeMailable.php
+++ b/src/Mail/TwoFactorCodeMailable.php
@@ -74,7 +74,7 @@ class TwoFactorCodeMailable extends Mailable
 	public function content(): Content
 	{
 		return new Content(
-			markdown: 'artisanpack-ui-security::emails.two-factor-code',
+			markdown: 'security-auth::emails.two-factor-code',
 			with:     [
 						  'code' => $this->code,
 					  ],

--- a/src/Models/AccountLockout.php
+++ b/src/Models/AccountLockout.php
@@ -1,0 +1,253 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AccountLockout extends Model
+{
+    /**
+     * Lockout types.
+     */
+    public const TYPE_TEMPORARY = 'temporary';
+
+    public const TYPE_PERMANENT = 'permanent';
+
+    public const TYPE_SOFT = 'soft';
+
+    /**
+     * The table associated with the model.
+     */
+    protected $table = 'account_lockouts';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * Note: is_active is a computed property (see isActive() method), not stored in DB.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'user_id',
+        'ip_address',
+        'lockout_type',
+        'reason',
+        'failed_attempts',
+        'locked_at',
+        'expires_at',
+        'unlocked_at',
+        'unlocked_by',
+        'unlock_reason',
+        'metadata',
+    ];
+
+    /**
+     * Set is_active (ignored - active status is computed).
+     */
+    public function setIsActiveAttribute( ?bool $value ): void
+    {
+        // is_active is a computed property, not stored
+    }
+
+    /**
+     * Get the user associated with this lockout.
+     *
+     * @return BelongsTo<\Illuminate\Foundation\Auth\User, AccountLockout>
+     */
+    public function user(): BelongsTo
+    {
+        $userModel = config( 'auth.providers.users.model', 'App\\Models\\User' );
+
+        return $this->belongsTo( $userModel );
+    }
+
+    /**
+     * Get the user who unlocked this lockout.
+     *
+     * @return BelongsTo<\Illuminate\Foundation\Auth\User, AccountLockout>
+     */
+    public function unlocker(): BelongsTo
+    {
+        $userModel = config( 'auth.providers.users.model', 'App\\Models\\User' );
+
+        return $this->belongsTo( $userModel, 'unlocked_by' );
+    }
+
+    /**
+     * Check if the lockout is currently active.
+     */
+    public function isActive(): bool
+    {
+        // If already unlocked, not active
+        if ( null !== $this->unlocked_at ) {
+            return false;
+        }
+
+        // Permanent lockouts are always active until unlocked
+        if ( self::TYPE_PERMANENT === $this->lockout_type ) {
+            return true;
+        }
+
+        // Temporary lockouts are active until expired
+        if ( null !== $this->expires_at ) {
+            return $this->expires_at->isFuture();
+        }
+
+        return true;
+    }
+
+    /**
+     * Get remaining lockout duration in seconds.
+     */
+    public function getRemainingSeconds(): int
+    {
+        if ( ! $this->isActive() || null === $this->expires_at ) {
+            return 0;
+        }
+
+        return max( 0, now()->diffInSeconds( $this->expires_at, false ) );
+    }
+
+    /**
+     * Unlock this lockout.
+     */
+    public function unlock( ?int $unlockedBy = null, ?string $reason = null ): void
+    {
+        $this->unlocked_at   = now();
+        $this->unlocked_by   = $unlockedBy;
+        $this->unlock_reason = $reason;
+        $this->save();
+    }
+
+    /**
+     * Check if this is a temporary lockout.
+     */
+    public function isTemporary(): bool
+    {
+        return self::TYPE_TEMPORARY === $this->lockout_type;
+    }
+
+    /**
+     * Check if this is a permanent lockout.
+     */
+    public function isPermanent(): bool
+    {
+        return self::TYPE_PERMANENT === $this->lockout_type;
+    }
+
+    /**
+     * Check if this is a soft lockout (CAPTCHA required).
+     */
+    public function isSoft(): bool
+    {
+        return self::TYPE_SOFT === $this->lockout_type;
+    }
+
+    /**
+     * Get a metadata value.
+     */
+    public function getMetadata( string $key ): mixed
+    {
+        return data_get( $this->metadata, $key );
+    }
+
+    /**
+     * Set a metadata value.
+     */
+    public function setMetadata( string $key, mixed $value ): void
+    {
+        $metadata = $this->metadata ?? [];
+        data_set( $metadata, $key, $value );
+        $this->metadata = $metadata;
+    }
+
+    /**
+     * Scope a query to only include active lockouts.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<AccountLockout>  $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<AccountLockout>
+     */
+    public function scopeActive( $query )
+    {
+        return $query->whereNull( 'unlocked_at' )
+            ->where( function ( $q ): void {
+                $q->where( 'lockout_type', self::TYPE_PERMANENT )
+                    ->orWhere( function ( $qq ): void {
+                        $qq->where( 'lockout_type', '!=', self::TYPE_PERMANENT )
+                            ->where( 'expires_at', '>', now() );
+                    } );
+            } );
+    }
+
+    /**
+     * Scope a query to only include lockouts for a specific user.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<AccountLockout>  $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<AccountLockout>
+     */
+    public function scopeForUser( $query, int $userId )
+    {
+        return $query->where( 'user_id', $userId );
+    }
+
+    /**
+     * Scope a query to only include lockouts for a specific IP.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<AccountLockout>  $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<AccountLockout>
+     */
+    public function scopeForIp( $query, string $ipAddress )
+    {
+        return $query->where( 'ip_address', $ipAddress );
+    }
+
+    /**
+     * Scope a query to only include expired lockouts.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<AccountLockout>  $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<AccountLockout>
+     */
+    public function scopeExpired( $query )
+    {
+        return $query->whereNull( 'unlocked_at' )
+            ->where( 'lockout_type', '!=', self::TYPE_PERMANENT )
+            ->where( 'expires_at', '<=', now() );
+    }
+
+    /**
+     * Boot the model.
+     */
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::creating( function ( AccountLockout $lockout ): void {
+            if ( null === $lockout->locked_at ) {
+                $lockout->locked_at = now();
+            }
+        } );
+    }
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'failed_attempts' => 'integer',
+            'locked_at'       => 'datetime',
+            'expires_at'      => 'datetime',
+            'unlocked_at'     => 'datetime',
+            'metadata'        => 'array',
+        ];
+    }
+}

--- a/src/Models/AccountLockout.php
+++ b/src/Models/AccountLockout.php
@@ -173,13 +173,13 @@ class AccountLockout extends Model
      */
     public function scopeActive( $query )
     {
+        // Mirror isActive(): a lockout is active when it hasn't been manually
+        // unlocked AND (it's permanent OR has no expiry OR expires in the future).
         return $query->whereNull( 'unlocked_at' )
             ->where( function ( $q ): void {
                 $q->where( 'lockout_type', self::TYPE_PERMANENT )
-                    ->orWhere( function ( $qq ): void {
-                        $qq->where( 'lockout_type', '!=', self::TYPE_PERMANENT )
-                            ->where( 'expires_at', '>', now() );
-                    } );
+                    ->orWhereNull( 'expires_at' )
+                    ->orWhere( 'expires_at', '>', now() );
             } );
     }
 

--- a/src/Models/PasswordHistory.php
+++ b/src/Models/PasswordHistory.php
@@ -1,0 +1,78 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PasswordHistory extends Model
+{
+    /**
+     * Indicates if the model should be timestamped.
+     *
+     * @var bool
+     */
+    public $timestamps = false;
+
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'password_history';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'user_id',
+        'password_hash',
+        'created_at',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'created_at' => 'datetime',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var array<int, string>
+     */
+    protected $hidden = [
+        'password_hash',
+    ];
+
+    /**
+     * Get the user that owns this password history entry.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo( config( 'auth.providers.users.model' ) );
+    }
+
+    /**
+     * Scope to get recent password history for a user.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  int  $userId
+     * @param  int  $limit
+     *
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeForUser( $query, int $userId, int $limit = 5 )
+    {
+        return $query->where( 'user_id', $userId )
+            ->orderByDesc( 'created_at' )
+            ->limit( $limit );
+    }
+}

--- a/src/Models/UserSession.php
+++ b/src/Models/UserSession.php
@@ -1,0 +1,287 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class UserSession extends Model
+{
+    /**
+     * Authentication methods.
+     */
+    public const AUTH_PASSWORD = 'password';
+
+    public const AUTH_SOCIAL = 'social';
+
+    public const AUTH_SSO = 'sso';
+
+    public const AUTH_WEBAUTHN = 'webauthn';
+
+    public const AUTH_BIOMETRIC = 'biometric';
+
+    public const AUTH_2FA = '2fa';
+
+    /**
+     * Indicates if the model should be timestamped.
+     */
+    public $timestamps = false;
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     */
+    public $incrementing = false;
+
+    /**
+     * The "type" of the primary key ID.
+     */
+    protected $keyType = 'string';
+
+    /**
+     * The table associated with the model.
+     */
+    protected $table = 'user_sessions';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'id',
+        'session_token',
+        'user_id',
+        'device_id',
+        'ip_address',
+        'user_agent',
+        'location',
+        'payload',
+        'auth_method',
+        'is_current',
+        'last_activity_at',
+        'expires_at',
+        'terminated_at',
+        'created_at',
+    ];
+
+    /**
+     * Set session_token (alias for id).
+     */
+    public function setSessionTokenAttribute( ?string $value ): void
+    {
+        $this->attributes['id'] = $value;
+    }
+
+    /**
+     * Get session_token (alias for id).
+     */
+    public function getSessionTokenAttribute(): ?string
+    {
+        return $this->id;
+    }
+
+    /**
+     * Get the user that owns this session.
+     *
+     * @return BelongsTo<\Illuminate\Foundation\Auth\User, UserSession>
+     */
+    public function user(): BelongsTo
+    {
+        $userModel = config( 'auth.providers.users.model', 'App\\Models\\User' );
+
+        return $this->belongsTo( $userModel );
+    }
+
+    /**
+     * Get the device associated with this session.
+     *
+     * @return BelongsTo<UserDevice, UserSession>
+     */
+    public function device(): BelongsTo
+    {
+        return $this->belongsTo( UserDevice::class, 'device_id' );
+    }
+
+    /**
+     * Check if the session is expired.
+     */
+    public function isExpired(): bool
+    {
+        return null !== $this->expires_at && $this->expires_at->isPast();
+    }
+
+    /**
+     * Check if the session is active (not expired and not terminated).
+     */
+    public function isActive(): bool
+    {
+        // A session is active if it's not expired and not terminated
+        if ( null !== $this->terminated_at ) {
+            return false;
+        }
+
+        return ! $this->isExpired();
+    }
+
+    /**
+     * Check if the session is idle (no activity within threshold).
+     */
+    public function isIdle( int $idleMinutes ): bool
+    {
+        if ( null === $this->last_activity_at ) {
+            return true;
+        }
+
+        return $this->last_activity_at->addMinutes( $idleMinutes )->isPast();
+    }
+
+    /**
+     * Touch the last activity timestamp.
+     */
+    public function touchActivity(): bool
+    {
+        $this->last_activity_at = now();
+
+        return $this->save();
+    }
+
+    /**
+     * Get a display name for the session location.
+     */
+    public function getLocationDisplay(): string
+    {
+        if ( empty( $this->location ) ) {
+            return 'Unknown location';
+        }
+
+        $parts = [];
+
+        if ( ! empty( $this->location['city'] ) ) {
+            $parts[] = $this->location['city'];
+        }
+
+        if ( ! empty( $this->location['region'] ) ) {
+            $parts[] = $this->location['region'];
+        }
+
+        if ( ! empty( $this->location['country'] ) ) {
+            $parts[] = $this->location['country'];
+        }
+
+        return implode( ', ', $parts ) ?: 'Unknown location';
+    }
+
+    /**
+     * Get a parsed user agent.
+     *
+     * @return array{browser: ?string, os: ?string}
+     */
+    public function getParsedUserAgent(): array
+    {
+        // Simple parsing - can be enhanced with a proper user agent parser
+        $ua      = $this->user_agent ?? '';
+        $browser = null;
+        $os      = null;
+
+        // Detect browser
+        if ( str_contains( $ua, 'Chrome' ) ) {
+            $browser = 'Chrome';
+        } elseif ( str_contains( $ua, 'Firefox' ) ) {
+            $browser = 'Firefox';
+        } elseif ( str_contains( $ua, 'Safari' ) ) {
+            $browser = 'Safari';
+        } elseif ( str_contains( $ua, 'Edge' ) ) {
+            $browser = 'Edge';
+        }
+
+        // Detect OS
+        if ( str_contains( $ua, 'Windows' ) ) {
+            $os = 'Windows';
+        } elseif ( str_contains( $ua, 'Mac OS' ) ) {
+            $os = 'macOS';
+        } elseif ( str_contains( $ua, 'Linux' ) ) {
+            $os = 'Linux';
+        } elseif ( str_contains( $ua, 'Android' ) ) {
+            $os = 'Android';
+        } elseif ( str_contains( $ua, 'iOS' ) || str_contains( $ua, 'iPhone' ) || str_contains( $ua, 'iPad' ) ) {
+            $os = 'iOS';
+        }
+
+        return ['browser' => $browser, 'os' => $os];
+    }
+
+    /**
+     * Scope a query to only include active (non-expired) sessions.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<UserSession>  $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<UserSession>
+     */
+    public function scopeActive( $query )
+    {
+        return $query->where( function ( $q ): void {
+            $q->whereNull( 'expires_at' )
+                ->orWhere( 'expires_at', '>', now() );
+        } )->whereNull( 'terminated_at' );
+    }
+
+    /**
+     * Scope a query to only include expired sessions.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<UserSession>  $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<UserSession>
+     */
+    public function scopeExpired( $query )
+    {
+        return $query->where( 'expires_at', '<=', now() );
+    }
+
+    /**
+     * Scope a query to order by most recent activity.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder<UserSession>  $query
+     *
+     * @return \Illuminate\Database\Eloquent\Builder<UserSession>
+     */
+    public function scopeLatestActivity( $query )
+    {
+        return $query->orderByDesc( 'last_activity_at' );
+    }
+
+    /**
+     * Boot the model.
+     */
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::creating( function ( UserSession $session ): void {
+            if ( empty( $session->id ) ) {
+                $session->id = \Illuminate\Support\Str::random( 64 );
+            }
+            if ( null === $session->created_at ) {
+                $session->created_at = now();
+            }
+        } );
+    }
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'location'         => 'array',
+            'is_current'       => 'boolean',
+            'last_activity_at' => 'datetime',
+            'expires_at'       => 'datetime',
+            'terminated_at'    => 'datetime',
+            'created_at'       => 'datetime',
+        ];
+    }
+}

--- a/src/Models/UserSession.php
+++ b/src/Models/UserSession.php
@@ -134,7 +134,7 @@ class UserSession extends Model
             return true;
         }
 
-        return $this->last_activity_at->addMinutes( $idleMinutes )->isPast();
+        return $this->last_activity_at->copy()->addMinutes( $idleMinutes )->isPast();
     }
 
     /**

--- a/src/Models/UserSession.php
+++ b/src/Models/UserSession.php
@@ -97,11 +97,24 @@ class UserSession extends Model
     /**
      * Get the device associated with this session.
      *
-     * @return BelongsTo<UserDevice, UserSession>
+     * UserDevice lives in artisanpack-ui/security-advanced-auth, which is
+     * an optional sibling package. Resolve the class lazily via FQCN string
+     * so the relation is a no-op (returns nothing) when that package isn't
+     * installed instead of throwing a ClassNotFoundException at boot.
+     *
+     * @return BelongsTo<Model, UserSession>
      */
     public function device(): BelongsTo
     {
-        return $this->belongsTo( UserDevice::class, 'device_id' );
+        $deviceModel = '\\ArtisanPackUI\\SecurityAdvancedAuth\\Models\\UserDevice';
+
+        if ( ! class_exists( $deviceModel ) ) {
+            // Fall back to a self-referential nullable relation: device_id
+            // is nullable, so the query returns no rows in this configuration.
+            return $this->belongsTo( static::class, 'device_id' );
+        }
+
+        return $this->belongsTo( $deviceModel, 'device_id' );
     }
 
     /**

--- a/src/Rules/NotCompromised.php
+++ b/src/Rules/NotCompromised.php
@@ -1,0 +1,64 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Rules;
+
+use ArtisanPackUI\SecurityAuth\Contracts\BreachCheckerInterface;
+use Illuminate\Contracts\Validation\Rule;
+
+class NotCompromised implements Rule
+{
+    /**
+     * The threshold for the number of times a password can appear in breaches.
+     */
+    protected int $threshold;
+
+    /**
+     * The number of times the password was found in breaches.
+     */
+    protected int $occurrences = 0;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @param  int  $threshold  Allow passwords that appear this many times or less in breaches
+     */
+    public function __construct( int $threshold = 0 )
+    {
+        $this->threshold = $threshold;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     */
+    public function passes( $attribute, $value ): bool
+    {
+        if ( ! config( 'artisanpack.security-auth.passwordSecurity.breachChecking.enabled', true ) ) {
+            return true;
+        }
+
+        $checker           = app( BreachCheckerInterface::class );
+        $this->occurrences = $checker->check( $value );
+
+        return $this->occurrences <= $this->threshold;
+    }
+
+    /**
+     * Get the validation error message.
+     */
+    public function message(): string
+    {
+        if ( $this->occurrences > 0 ) {
+            return sprintf(
+                'This password has appeared in %s data breach(es) and should not be used. Please choose a different password.',
+                number_format( $this->occurrences ),
+            );
+        }
+
+        return 'This password has been compromised in a data breach. Please choose a different password.';
+    }
+}

--- a/src/Rules/PasswordComplexity.php
+++ b/src/Rules/PasswordComplexity.php
@@ -38,7 +38,14 @@ class PasswordComplexity implements Rule
     public function passes( $attribute, $value ): bool
     {
         $this->errors = [];
-        $config       = config( 'artisanpack.security-auth.passwordSecurity.complexity', [] );
+
+        if ( ! is_string( $value ) ) {
+            $this->errors[] = 'Password must be a string.';
+
+            return false;
+        }
+
+        $config = config( 'artisanpack.security-auth.passwordSecurity.complexity', [] );
 
         // Length checks
         $minLength = $config['minLength'] ?? 8;

--- a/src/Rules/PasswordComplexity.php
+++ b/src/Rules/PasswordComplexity.php
@@ -1,0 +1,172 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Rules;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Validation\Rule;
+
+class PasswordComplexity implements Rule
+{
+    /**
+     * The validation errors.
+     *
+     * @var array<int, string>
+     */
+    protected array $errors = [];
+
+    /**
+     * The user for context-aware validation.
+     */
+    protected ?Authenticatable $user;
+
+    /**
+     * Create a new rule instance.
+     */
+    public function __construct( ?Authenticatable $user = null )
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     */
+    public function passes( $attribute, $value ): bool
+    {
+        $this->errors = [];
+        $config       = config( 'artisanpack.security-auth.passwordSecurity.complexity', [] );
+
+        // Length checks
+        $minLength = $config['minLength'] ?? 8;
+        $maxLength = $config['maxLength'] ?? 128;
+
+        if ( strlen( $value ) < $minLength ) {
+            $this->errors[] = "Password must be at least {$minLength} characters.";
+        }
+
+        if ( strlen( $value ) > $maxLength ) {
+            $this->errors[] = "Password must not exceed {$maxLength} characters.";
+        }
+
+        // Character type requirements
+        if ( ( $config['requireUppercase'] ?? true ) && ! preg_match( '/[A-Z]/', $value ) ) {
+            $this->errors[] = 'Password must contain at least one uppercase letter.';
+        }
+
+        if ( ( $config['requireLowercase'] ?? true ) && ! preg_match( '/[a-z]/', $value ) ) {
+            $this->errors[] = 'Password must contain at least one lowercase letter.';
+        }
+
+        if ( ( $config['requireNumbers'] ?? true ) && ! preg_match( '/[0-9]/', $value ) ) {
+            $this->errors[] = 'Password must contain at least one number.';
+        }
+
+        if ( ( $config['requireSymbols'] ?? true ) && ! preg_match( '/[^A-Za-z0-9]/', $value ) ) {
+            $this->errors[] = 'Password must contain at least one special character.';
+        }
+
+        // Unique characters
+        $minUnique = $config['minUniqueCharacters'] ?? 4;
+        if ( count( array_unique( str_split( $value ) ) ) < $minUnique ) {
+            $this->errors[] = "Password must contain at least {$minUnique} unique characters.";
+        }
+
+        // Repeating characters
+        $maxRepeat = $config['disallowRepeatingCharacters'] ?? 3;
+        if ( $maxRepeat > 0 && preg_match( '/(.)\1{' . $maxRepeat . ',}/', $value ) ) {
+            $this->errors[] = "Password must not contain more than {$maxRepeat} consecutive repeating characters.";
+        }
+
+        // Sequential characters
+        $maxSequential = $config['disallowSequentialCharacters'] ?? 3;
+        if ( $maxSequential > 0 && $this->hasSequentialCharacters( $value, $maxSequential ) ) {
+            $this->errors[] = "Password must not contain more than {$maxSequential} sequential characters.";
+        }
+
+        // User attributes check
+        if ( ( $config['disallowUserAttributes'] ?? true ) && $this->user ) {
+            $this->checkUserAttributes( $value );
+        }
+
+        return empty( $this->errors );
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array<int, string>|string
+     */
+    public function message(): array|string
+    {
+        return $this->errors;
+    }
+
+    /**
+     * Check if password contains sequential characters.
+     */
+    protected function hasSequentialCharacters( string $value, int $maxSequential ): bool
+    {
+        $sequences = [
+            'abcdefghijklmnopqrstuvwxyz',
+            'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+            '0123456789',
+            'qwertyuiop',
+            'asdfghjkl',
+            'zxcvbnm',
+        ];
+
+        $lowerValue = strtolower( $value );
+
+        foreach ( $sequences as $sequence ) {
+            $sequence  = strtolower( $sequence );
+            $chunkSize = $maxSequential + 1;
+            for ( $i = 0; $i <= strlen( $sequence ) - $chunkSize; $i++ ) {
+                $chunk = substr( $sequence, $i, $chunkSize );
+                if ( str_contains( $lowerValue, $chunk ) ) {
+                    return true;
+                }
+                // Check reverse
+                if ( str_contains( $lowerValue, strrev( $chunk ) ) ) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if password contains user attributes.
+     */
+    protected function checkUserAttributes( string $value ): void
+    {
+        $lowerValue = strtolower( $value );
+        $attributes = ['email', 'name', 'username', 'first_name', 'last_name'];
+
+        foreach ( $attributes as $attr ) {
+            if ( isset( $this->user->{$attr} ) ) {
+                $attrValue = strtolower( (string) $this->user->{$attr} );
+                // Check if attribute value (or parts of it) are in password
+                if ( strlen( $attrValue ) >= 3 ) {
+                    // Check email local part
+                    if ( 'email' === $attr ) {
+                        $localPart = explode( '@', $attrValue )[0];
+                        if ( strlen( $localPart ) >= 3 && str_contains( $lowerValue, $localPart ) ) {
+                            $this->errors[] = 'Password must not contain parts of your email address.';
+
+                            continue;
+                        }
+                    }
+
+                    if ( str_contains( $lowerValue, $attrValue)) {
+                        $this->errors[] = "Password must not contain your {$attr}.";
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Rules/PasswordComplexity.php
+++ b/src/Rules/PasswordComplexity.php
@@ -44,11 +44,12 @@ class PasswordComplexity implements Rule
         $minLength = $config['minLength'] ?? 8;
         $maxLength = $config['maxLength'] ?? 128;
 
-        if ( strlen( $value ) < $minLength ) {
+        // Use mb_strlen so multi-byte characters count as one character apiece.
+        if ( mb_strlen( $value, 'UTF-8' ) < $minLength ) {
             $this->errors[] = "Password must be at least {$minLength} characters.";
         }
 
-        if ( strlen( $value ) > $maxLength ) {
+        if ( mb_strlen( $value, 'UTF-8' ) > $maxLength ) {
             $this->errors[] = "Password must not exceed {$maxLength} characters.";
         }
 
@@ -71,7 +72,8 @@ class PasswordComplexity implements Rule
 
         // Unique characters
         $minUnique = $config['minUniqueCharacters'] ?? 4;
-        if ( count( array_unique( str_split( $value ) ) ) < $minUnique ) {
+        $chars     = preg_split( '//u', $value, -1, PREG_SPLIT_NO_EMPTY ) ?: [];
+        if ( count( array_unique( $chars ) ) < $minUnique ) {
             $this->errors[] = "Password must contain at least {$minUnique} unique characters.";
         }
 
@@ -119,10 +121,10 @@ class PasswordComplexity implements Rule
             'zxcvbnm',
         ];
 
-        $lowerValue = strtolower( $value );
+        $lowerValue = mb_strtolower( $value, 'UTF-8' );
 
         foreach ( $sequences as $sequence ) {
-            $sequence  = strtolower( $sequence );
+            $sequence  = mb_strtolower( $sequence, 'UTF-8' );
             $chunkSize = $maxSequential + 1;
             for ( $i = 0; $i <= strlen( $sequence ) - $chunkSize; $i++ ) {
                 $chunk = substr( $sequence, $i, $chunkSize );
@@ -162,7 +164,7 @@ class PasswordComplexity implements Rule
                         }
                     }
 
-                    if ( str_contains( $lowerValue, $attrValue)) {
+                    if ( str_contains( $lowerValue, $attrValue ) ) {
                         $this->errors[] = "Password must not contain your {$attr}.";
                     }
                 }

--- a/src/Rules/PasswordHistoryRule.php
+++ b/src/Rules/PasswordHistoryRule.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Rules;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Validation\Rule;
+
+class PasswordHistoryRule implements Rule
+{
+    /**
+     * The user for history checking.
+     */
+    protected ?Authenticatable $user;
+
+    /**
+     * Create a new rule instance.
+     */
+    public function __construct( ?Authenticatable $user = null )
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     */
+    public function passes( $attribute, $value ): bool
+    {
+        if ( ! config( 'artisanpack.security-auth.passwordSecurity.history.enabled', false ) ) {
+            return true;
+        }
+
+        if ( null === $this->user ) {
+            return true;
+        }
+
+        if ( ! method_exists( $this->user, 'passwordExistsInHistory' ) ) {
+            return true;
+        }
+
+        return ! $this->user->passwordExistsInHistory( $value );
+    }
+
+    /**
+     * Get the validation error message.
+     */
+    public function message(): string
+    {
+        $count = config( 'artisanpack.security-auth.passwordSecurity.history.count', 5 );
+
+        return "You cannot reuse any of your last {$count} passwords.";
+    }
+}

--- a/src/Rules/PasswordPolicy.php
+++ b/src/Rules/PasswordPolicy.php
@@ -1,5 +1,7 @@
 <?php
 
+declare( strict_types=1 );
+
 namespace ArtisanPackUI\SecurityAuth\Rules;
 
 use Illuminate\Contracts\Validation\Rule;
@@ -11,19 +13,16 @@ class PasswordPolicy implements Rule
     /**
      * The validation errors.
      *
-     * @var array
+     * @var array<int, string>
      */
-    protected $errors = [];
+    protected array $errors = [];
 
     /**
      * Determine if the validation rule passes.
      *
      * @param  string  $attribute
-     * @param  mixed  $value
-     *
-     * @return bool
      */
-    public function passes( $attribute, $value )
+    public function passes( $attribute, mixed $value ): bool
     {
         $validator = Validator::make( ['password' => $value], [
             'password' => [
@@ -32,13 +31,17 @@ class PasswordPolicy implements Rule
                     ->letters()
                     ->mixedCase()
                     ->numbers()
-                    ->symbols()
-                    ->uncompromised(),
+                    ->symbols(),
+                // Delegate breach checking to the package's NotCompromised rule
+                // so config flags + outage protection in HaveIBeenPwnedService
+                // are honored (vs. Password::uncompromised() which bypasses them).
+                new NotCompromised(),
             ],
         ] );
 
         if ( $validator->fails() ) {
             $this->errors = $validator->errors()->all();
+
             return false;
         }
 
@@ -48,9 +51,9 @@ class PasswordPolicy implements Rule
     /**
      * Get the validation error message.
      *
-     * @return array
+     * @return array<int, string>
      */
-    public function message()
+    public function message(): array
     {
         return $this->errors;
     }

--- a/src/Rules/PasswordPolicy.php
+++ b/src/Rules/PasswordPolicy.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace ArtisanPackUI\SecurityAuth\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\Password;
+
+class PasswordPolicy implements Rule
+{
+    /**
+     * The validation errors.
+     *
+     * @var array
+     */
+    protected $errors = [];
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     *
+     * @return bool
+     */
+    public function passes( $attribute, $value )
+    {
+        $validator = Validator::make( ['password' => $value], [
+            'password' => [
+                'required',
+                Password::min( 8 )
+                    ->letters()
+                    ->mixedCase()
+                    ->numbers()
+                    ->symbols()
+                    ->uncompromised(),
+            ],
+        ] );
+
+        if ( $validator->fails() ) {
+            $this->errors = $validator->errors()->all();
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return array
+     */
+    public function message()
+    {
+        return $this->errors;
+    }
+}

--- a/src/SecurityAuthServiceProvider.php
+++ b/src/SecurityAuthServiceProvider.php
@@ -59,6 +59,8 @@ class SecurityAuthServiceProvider extends ServiceProvider
         $this->loadMigrationsFrom( __DIR__ . '/../database/migrations/password' );
         $this->loadMigrationsFrom( __DIR__ . '/../database/migrations/authentication' );
 
+        $this->loadViewsFrom( __DIR__ . '/../resources/views', 'security-auth' );
+
         $this->registerMiddleware();
         $this->registerCommands();
         $this->registerLivewireComponents();

--- a/src/SecurityAuthServiceProvider.php
+++ b/src/SecurityAuthServiceProvider.php
@@ -9,6 +9,7 @@ use ArtisanPackUI\SecurityAuth\Authentication\Contracts\SessionSecurityInterface
 use ArtisanPackUI\SecurityAuth\Authentication\Lockout\AccountLockoutManager;
 use ArtisanPackUI\SecurityAuth\Authentication\Session\AdvancedSessionManager;
 use ArtisanPackUI\SecurityAuth\Console\Commands\ManageAccountLockout;
+use ArtisanPackUI\SecurityAuth\Contracts\BreachCheckerInterface;
 use ArtisanPackUI\SecurityAuth\Contracts\PasswordSecurityServiceInterface;
 use ArtisanPackUI\SecurityAuth\Http\Middleware\CheckAccountLockout;
 use ArtisanPackUI\SecurityAuth\Http\Middleware\EnforcePasswordPolicy;
@@ -81,9 +82,13 @@ class SecurityAuthServiceProvider extends ServiceProvider
             return new HaveIBeenPwnedService();
         } );
 
+        // Bind the contract so NotCompromised + PasswordPolicy can resolve
+        // the same instance that PasswordSecurityService uses.
+        $this->app->bind( BreachCheckerInterface::class, HaveIBeenPwnedService::class );
+
         $this->app->singleton( PasswordSecurityServiceInterface::class, function ( $app ) {
             return new PasswordSecurityService(
-                $app->make( HaveIBeenPwnedService::class ),
+                $app->make( BreachCheckerInterface::class ),
             );
         } );
     }

--- a/src/SecurityAuthServiceProvider.php
+++ b/src/SecurityAuthServiceProvider.php
@@ -1,70 +1,141 @@
 <?php
 
-/**
- * Package service provider.
- *
- * Bootstraps the Package by registering services and bindings.
- *
- * @package    ArtisanPack_UI
- * @subpackage SecurityAuth
- *
- * @author     Jacob Martella <me@jacobmartella.com>
- *
- * @since      1.0.0
- */
-
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth;
 
+use ArtisanPackUI\SecurityAuth\Authentication\Contracts\AccountLockoutInterface;
+use ArtisanPackUI\SecurityAuth\Authentication\Contracts\SessionSecurityInterface;
+use ArtisanPackUI\SecurityAuth\Authentication\Lockout\AccountLockoutManager;
+use ArtisanPackUI\SecurityAuth\Authentication\Session\AdvancedSessionManager;
+use ArtisanPackUI\SecurityAuth\Console\Commands\ManageAccountLockout;
+use ArtisanPackUI\SecurityAuth\Contracts\PasswordSecurityServiceInterface;
+use ArtisanPackUI\SecurityAuth\Http\Middleware\CheckAccountLockout;
+use ArtisanPackUI\SecurityAuth\Http\Middleware\EnforcePasswordPolicy;
+use ArtisanPackUI\SecurityAuth\Http\Middleware\StepUpAuthentication;
+use ArtisanPackUI\SecurityAuth\Http\Middleware\TwoFactorMiddleware;
+use ArtisanPackUI\SecurityAuth\Services\HaveIBeenPwnedService;
+use ArtisanPackUI\SecurityAuth\Services\PasswordSecurityService;
+use ArtisanPackUI\SecurityAuth\TwoFactor\TwoFactorManager;
 use Illuminate\Support\ServiceProvider;
 
 /**
- * Service provider for the Package.
+ * Security Auth service provider.
  *
- * Bootstraps the Package by registering services and bindings.
- * Extend this class with your package's configuration, migrations,
- * routes, views, and other service registrations.
+ * Registers two-factor authentication, password security, account lockout,
+ * and advanced session management services for Laravel applications.
  *
- * @package    ArtisanPack_UI
- * @subpackage SecurityAuth
- *
- * @since      1.0.0
+ * @since 1.0.0
  */
 class SecurityAuthServiceProvider extends ServiceProvider
 {
-    /**
-     * Registers any application services.
-     *
-     * Binds the Package class as a singleton in the container.
-     * Add additional service registrations here.
-     *
-     * @since 1.0.0
-     *
-     * @return void
-     */
     public function register(): void
     {
+        $this->mergeConfigFrom(
+            __DIR__ . '/../config/artisanpack/security-auth.php',
+            'artisanpack.security-auth',
+        );
+
         $this->app->singleton( 'security-auth', function ( $app ) {
             return new SecurityAuth();
         } );
+
+        $this->registerTwoFactor();
+        $this->registerPasswordSecurity();
+        $this->registerAccountLockout();
+        $this->registerAdvancedSessions();
     }
 
-    /**
-     * Bootstraps any application services.
-     *
-     * Add package bootstrapping here such as:
-     * - Configuration publishing: $this->publishes([...])
-     * - Migration loading: $this->loadMigrationsFrom(...)
-     * - View loading: $this->loadViewsFrom(...)
-     * - Route loading: $this->loadRoutesFrom(...)
-     *
-     * @since 1.0.0
-     *
-     * @return void
-     */
     public function boot(): void
     {
-        // Add your package bootstrapping here
+        $this->publishes(
+            [
+                __DIR__ . '/../config/artisanpack/security-auth.php' => config_path( 'artisanpack/security-auth.php' ),
+            ],
+            'security-auth-config',
+        );
+
+        $this->loadMigrationsFrom( __DIR__ . '/../database/migrations' );
+        $this->loadMigrationsFrom( __DIR__ . '/../database/migrations/password' );
+        $this->loadMigrationsFrom( __DIR__ . '/../database/migrations/authentication' );
+
+        $this->registerMiddleware();
+        $this->registerCommands();
+        $this->registerLivewireComponents();
+    }
+
+    protected function registerTwoFactor(): void
+    {
+        $this->app->singleton( TwoFactorManager::class, function () {
+            return new TwoFactorManager();
+        } );
+
+        $this->app->alias( TwoFactorManager::class, 'security-auth.two-factor' );
+    }
+
+    protected function registerPasswordSecurity(): void
+    {
+        $this->app->singleton( HaveIBeenPwnedService::class, function () {
+            return new HaveIBeenPwnedService();
+        } );
+
+        $this->app->singleton( PasswordSecurityServiceInterface::class, function ( $app ) {
+            return new PasswordSecurityService(
+                $app->make( HaveIBeenPwnedService::class ),
+            );
+        } );
+    }
+
+    protected function registerAccountLockout(): void
+    {
+        $this->app->singleton( AccountLockoutManager::class, function () {
+            return new AccountLockoutManager();
+        } );
+
+        $this->app->bind( AccountLockoutInterface::class, AccountLockoutManager::class );
+    }
+
+    protected function registerAdvancedSessions(): void
+    {
+        $this->app->singleton( AdvancedSessionManager::class, function () {
+            return new AdvancedSessionManager();
+        } );
+
+        $this->app->bind( SessionSecurityInterface::class, AdvancedSessionManager::class );
+    }
+
+    protected function registerMiddleware(): void
+    {
+        $router = $this->app['router'];
+
+        $router->aliasMiddleware( 'two-factor', TwoFactorMiddleware::class );
+        $router->aliasMiddleware( 'password.policy', EnforcePasswordPolicy::class );
+        $router->aliasMiddleware( 'check.lockout', CheckAccountLockout::class );
+        $router->aliasMiddleware( 'step-up', StepUpAuthentication::class );
+    }
+
+    protected function registerCommands(): void
+    {
+        if ( ! $this->app->runningInConsole() ) {
+            return;
+        }
+
+        $this->commands(
+            [
+                ManageAccountLockout::class,
+            ],
+        );
+    }
+
+    protected function registerLivewireComponents(): void
+    {
+        if ( ! class_exists( \Livewire\Livewire::class ) || ! $this->app->bound( 'livewire' ) ) {
+            return;
+        }
+
+        \Livewire\Livewire::component( 'password-strength-meter', Livewire\PasswordStrengthMeter::class );
+        \Livewire\Livewire::component( 'account-lockout-status', Livewire\AccountLockoutStatus::class );
+        \Livewire\Livewire::component( 'session-manager', Livewire\SessionManager::class );
+        \Livewire\Livewire::component( 'step-up-authentication-modal', Livewire\StepUpAuthenticationModal::class );
     }
 }

--- a/src/Services/HaveIBeenPwnedService.php
+++ b/src/Services/HaveIBeenPwnedService.php
@@ -36,12 +36,30 @@ class HaveIBeenPwnedService implements BreachCheckerInterface
         $prefix = substr( $sha1, 0, 5 );
         $suffix = substr( $sha1, 5 );
 
-        // Check cache first
+        // Cache::remember() reruns the loader whenever the stored value is null,
+        // so an API outage would leave every password check waiting on a fresh
+        // 5-second HTTP timeout. Read-then-write so we only cache successes,
+        // and fail-cache outages briefly to avoid hammering a degraded API.
         if ( config( 'artisanpack.security-auth.passwordSecurity.breachChecking.cacheResults', true ) ) {
-            $cacheKey = "hibp_prefix_{$prefix}";
-            $ttl      = config( 'artisanpack.security-auth.passwordSecurity.breachChecking.cacheTtl', 86400 );
+            $cacheKey     = "hibp_prefix_{$prefix}";
+            $failCacheKey = "hibp_fail_{$prefix}";
+            $ttl          = config( 'artisanpack.security-auth.passwordSecurity.breachChecking.cacheTtl', 86400 );
 
-            $results = Cache::remember( $cacheKey, $ttl, fn () => $this->fetchFromApi( $prefix ) );
+            if ( Cache::has( $failCacheKey ) ) {
+                return 0;
+            }
+
+            $results = Cache::get( $cacheKey );
+
+            if ( null === $results ) {
+                $results = $this->fetchFromApi( $prefix );
+
+                if ( null === $results ) {
+                    Cache::put( $failCacheKey, true, 60 );
+                } else {
+                    Cache::put( $cacheKey, $results, $ttl );
+                }
+            }
         } else {
             $results = $this->fetchFromApi( $prefix );
         }
@@ -110,7 +128,7 @@ class HaveIBeenPwnedService implements BreachCheckerInterface
             Log::error( 'HIBP API request failed', [
                 'error'  => $e->getMessage(),
                 'prefix' => $prefix,
-            ]);
+            ] );
 
             return null;
         }

--- a/src/Services/HaveIBeenPwnedService.php
+++ b/src/Services/HaveIBeenPwnedService.php
@@ -1,0 +1,118 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Services;
+
+use ArtisanPackUI\SecurityAuth\Contracts\BreachCheckerInterface;
+use Exception;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class HaveIBeenPwnedService implements BreachCheckerInterface
+{
+    /**
+     * The HaveIBeenPwned API URL.
+     */
+    protected const API_URL = 'https://api.pwnedpasswords.com/range/';
+
+    /**
+     * Check if a password has been exposed in known data breaches.
+     *
+     * Uses k-Anonymity model - only first 5 chars of SHA1 hash are sent.
+     *
+     * @param  string  $password  The plain-text password to check
+     *
+     * @return int Number of times password has been seen in breaches
+     */
+    public function check( string $password ): int
+    {
+        if ( ! config( 'artisanpack.security-auth.passwordSecurity.breachChecking.enabled', true ) ) {
+            return 0;
+        }
+
+        $sha1   = strtoupper( sha1( $password ) );
+        $prefix = substr( $sha1, 0, 5 );
+        $suffix = substr( $sha1, 5 );
+
+        // Check cache first
+        if ( config( 'artisanpack.security-auth.passwordSecurity.breachChecking.cacheResults', true ) ) {
+            $cacheKey = "hibp_prefix_{$prefix}";
+            $ttl      = config( 'artisanpack.security-auth.passwordSecurity.breachChecking.cacheTtl', 86400 );
+
+            $results = Cache::remember( $cacheKey, $ttl, fn () => $this->fetchFromApi( $prefix ) );
+        } else {
+            $results = $this->fetchFromApi( $prefix );
+        }
+
+        if ( null === $results ) {
+            // API failed, fail open (don't block user)
+            return 0;
+        }
+
+        // Search for our suffix in the results
+        foreach ( explode( "\n", $results ) as $line ) {
+            $line = trim( $line );
+            if ( empty( $line ) ) {
+                continue;
+            }
+
+            $parts = explode( ':', $line );
+            if ( 2 !== count( $parts ) ) {
+                continue;
+            }
+
+            [$hashSuffix, $count] = $parts;
+
+            if ( strtoupper( $hashSuffix ) === $suffix ) {
+                return (int) $count;
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * Check if password is compromised.
+     */
+    public function isCompromised( string $password ): bool
+    {
+        return $this->check( $password ) > 0;
+    }
+
+    /**
+     * Fetch hash range from HIBP API.
+     */
+    protected function fetchFromApi( string $prefix ): ?string
+    {
+        try {
+            $timeout = config( 'artisanpack.security-auth.passwordSecurity.breachChecking.apiTimeout', 5 );
+
+            $response = Http::timeout( $timeout )
+                ->withHeaders( [
+                    'User-Agent'  => 'ArtisanPack-Security-Laravel-Package',
+                    'Add-Padding' => 'true', // Enable padding for privacy
+                ] )
+                ->get( self::API_URL . $prefix );
+
+            if ( $response->successful() ) {
+                return $response->body();
+            }
+
+            Log::warning( 'HIBP API returned non-success status', [
+                'status' => $response->status(),
+                'prefix' => $prefix,
+            ] );
+
+            return null;
+        } catch ( Exception $e ) {
+            Log::error( 'HIBP API request failed', [
+                'error'  => $e->getMessage(),
+                'prefix' => $prefix,
+            ]);
+
+            return null;
+        }
+    }
+}

--- a/src/Services/PasswordSecurityService.php
+++ b/src/Services/PasswordSecurityService.php
@@ -8,6 +8,7 @@ use ArtisanPackUI\SecurityAuth\Contracts\BreachCheckerInterface;
 use ArtisanPackUI\SecurityAuth\Contracts\PasswordSecurityServiceInterface;
 use ArtisanPackUI\SecurityAuth\Models\PasswordHistory;
 use ArtisanPackUI\SecurityAuth\Rules\PasswordComplexity;
+use DateTimeInterface;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Hash;
 
@@ -149,9 +150,10 @@ class PasswordSecurityService implements PasswordSecurityServiceInterface
             return $user->passwordHasExpired();
         }
 
-        // Fallback: check directly if user has the column
-        if ( isset( $user->password_expires_at ) && null !== $user->password_expires_at ) {
-            return $user->password_expires_at->isPast();
+        // Fallback: check directly if user has the column. Guard against
+        // string timestamps from models without a `datetime` cast.
+        if ( isset( $user->password_expires_at ) && $user->password_expires_at instanceof DateTimeInterface ) {
+            return $user->password_expires_at->getTimestamp() < time();
         }
 
         return false;
@@ -166,7 +168,7 @@ class PasswordSecurityService implements PasswordSecurityServiceInterface
             return $user->daysUntilPasswordExpires();
         }
 
-        if ( isset( $user->password_expires_at ) && null !== $user->password_expires_at ) {
+        if ( isset( $user->password_expires_at ) && $user->password_expires_at instanceof DateTimeInterface ) {
             $days = (int) now()->diffInDays( $user->password_expires_at, false );
 
             return max( 0, $days );

--- a/src/Services/PasswordSecurityService.php
+++ b/src/Services/PasswordSecurityService.php
@@ -1,0 +1,306 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\SecurityAuth\Services;
+
+use ArtisanPackUI\SecurityAuth\Contracts\BreachCheckerInterface;
+use ArtisanPackUI\SecurityAuth\Contracts\PasswordSecurityServiceInterface;
+use ArtisanPackUI\SecurityAuth\Models\PasswordHistory;
+use ArtisanPackUI\SecurityAuth\Rules\PasswordComplexity;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\Hash;
+
+class PasswordSecurityService implements PasswordSecurityServiceInterface
+{
+    /**
+     * The breach checker instance.
+     */
+    protected BreachCheckerInterface $breachChecker;
+
+    /**
+     * Create a new service instance.
+     */
+    public function __construct( BreachCheckerInterface $breachChecker )
+    {
+        $this->breachChecker = $breachChecker;
+    }
+
+    /**
+     * Validate a password against all configured policies.
+     */
+    public function validatePassword( string $password, ?Authenticatable $user = null ): array
+    {
+        $errors = [];
+
+        // Check complexity
+        $complexityErrors = $this->checkComplexity( $password, $user );
+        $errors           = array_merge( $errors, $complexityErrors );
+
+        // Check history if user provided
+        if ( null !== $user && $this->isInHistory( $password, $user ) ) {
+            $count    = config( 'artisanpack.security-auth.passwordSecurity.history.count', 5 );
+            $errors[] = "You cannot reuse any of your last {$count} passwords.";
+        }
+
+        // Check if password change is allowed (minimum days between changes)
+        if ( null !== $user && method_exists( $user, 'canChangePassword' ) && ! $user->canChangePassword() ) {
+            $days = method_exists( $user, 'daysUntilCanChangePassword' )
+                ? $user->daysUntilCanChangePassword()
+                : config( 'artisanpack.security-auth.passwordSecurity.history.minDaysBetweenChanges', 1 );
+            $errors[] = "You must wait {$days} more day(s) before changing your password again.";
+        }
+
+        // Check breach status
+        if ( config( 'artisanpack.security-auth.passwordSecurity.breachChecking.enabled', true ) ) {
+            if ( config( 'artisanpack.security-auth.passwordSecurity.breachChecking.blockCompromised', true ) ) {
+                $occurrences = $this->breachChecker->check( $password );
+                if ( $occurrences > 0 ) {
+                    $errors[] = sprintf(
+                        'This password has appeared in %s data breach(es) and should not be used.',
+                        number_format( $occurrences ),
+                    );
+                }
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Check if a password meets complexity requirements.
+     */
+    public function checkComplexity( string $password, ?Authenticatable $user = null ): array
+    {
+        $rule = new PasswordComplexity( $user );
+
+        if ( ! $rule->passes( 'password', $password ) ) {
+            $message = $rule->message();
+
+            return is_array( $message ) ? $message : [$message];
+        }
+
+        return [];
+    }
+
+    /**
+     * Check if password exists in user's history.
+     */
+    public function isInHistory( string $password, Authenticatable $user ): bool
+    {
+        if ( ! config( 'artisanpack.security-auth.passwordSecurity.history.enabled', false ) ) {
+            return false;
+        }
+
+        if ( method_exists( $user, 'passwordExistsInHistory' ) ) {
+            return $user->passwordExistsInHistory( $password );
+        }
+
+        // Fallback: query directly
+        $count = config( 'artisanpack.security-auth.passwordSecurity.history.count', 5 );
+
+        $recentPasswords = PasswordHistory::forUser( $user->getAuthIdentifier(), $count )
+            ->pluck( 'password_hash' );
+
+        foreach ( $recentPasswords as $hashedPassword ) {
+            if ( Hash::check( $password, $hashedPassword ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Record a password in user's history.
+     */
+    public function recordPassword( string $hashedPassword, Authenticatable $user ): void
+    {
+        if ( ! config( 'artisanpack.security-auth.passwordSecurity.history.enabled', false ) ) {
+            return;
+        }
+
+        if ( method_exists( $user, 'recordPasswordInHistory' ) ) {
+            $user->recordPasswordInHistory( $hashedPassword );
+
+            return;
+        }
+
+        // Fallback: insert directly
+        PasswordHistory::create( [
+            'user_id'       => $user->getAuthIdentifier(),
+            'password_hash' => $hashedPassword,
+            'created_at'    => now(),
+        ] );
+
+        $this->pruneHistory( $user );
+    }
+
+    /**
+     * Check if user's password has expired.
+     */
+    public function isExpired( Authenticatable $user ): bool
+    {
+        if ( ! config( 'artisanpack.security-auth.passwordSecurity.expiration.enabled', false ) ) {
+            return false;
+        }
+
+        if ( method_exists( $user, 'passwordHasExpired' ) ) {
+            return $user->passwordHasExpired();
+        }
+
+        // Fallback: check directly if user has the column
+        if ( isset( $user->password_expires_at ) && null !== $user->password_expires_at ) {
+            return $user->password_expires_at->isPast();
+        }
+
+        return false;
+    }
+
+    /**
+     * Get days until password expires.
+     */
+    public function daysUntilExpiration( Authenticatable $user ): ?int
+    {
+        if ( method_exists( $user, 'daysUntilPasswordExpires' ) ) {
+            return $user->daysUntilPasswordExpires();
+        }
+
+        if ( isset( $user->password_expires_at ) && null !== $user->password_expires_at ) {
+            $days = (int) now()->diffInDays( $user->password_expires_at, false );
+
+            return max( 0, $days );
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if password has been compromised in known breaches.
+     */
+    public function isCompromised( string $password ): bool
+    {
+        return $this->breachChecker->isCompromised( $password );
+    }
+
+    /**
+     * Calculate password strength score (0-4).
+     */
+    public function calculateStrength( string $password, array $userInputs = [] ): array
+    {
+        // Check if zxcvbn-php is available
+        if ( class_exists( \ZxcvbnPhp\Zxcvbn::class ) ) {
+            return $this->calculateStrengthWithZxcvbn( $password, $userInputs );
+        }
+
+        // Fallback to simple strength calculation
+        return $this->calculateStrengthSimple( $password );
+    }
+
+    /**
+     * Prune old password history records.
+     */
+    public function pruneHistory( Authenticatable $user ): int
+    {
+        if ( method_exists( $user, 'prunePasswordHistory' ) ) {
+            return $user->prunePasswordHistory();
+        }
+
+        // Fallback: prune directly
+        $count  = config( 'artisanpack.security-auth.passwordSecurity.history.count', 5 );
+        $userId = $user->getAuthIdentifier();
+
+        $idsToKeep = PasswordHistory::forUser( $userId, $count )->pluck( 'id' );
+
+        return PasswordHistory::where( 'user_id', $userId )
+            ->whereNotIn( 'id', $idsToKeep )
+            ->delete();
+    }
+
+    /**
+     * Calculate strength using zxcvbn-php library.
+     */
+    protected function calculateStrengthWithZxcvbn( string $password, array $userInputs ): array
+    {
+        $zxcvbn = new \ZxcvbnPhp\Zxcvbn();
+        $result = $zxcvbn->passwordStrength( $password, $userInputs );
+
+        $labels = ['Very Weak', 'Weak', 'Fair', 'Strong', 'Very Strong'];
+
+        return [
+            'score'     => $result['score'],
+            'label'     => $labels[ $result['score'] ] ?? 'Unknown',
+            'crackTime' => $result['crack_times_display']['offline_slow_hashing_1e4_per_second'] ?? '',
+            'feedback'  => array_merge(
+                $result['feedback']['warning'] ? [$result['feedback']['warning']] : [],
+                $result['feedback']['suggestions'] ?? [],
+            ),
+        ];
+    }
+
+    /**
+     * Calculate strength using simple algorithm (fallback).
+     */
+    protected function calculateStrengthSimple( string $password ): array
+    {
+        $score    = 0;
+        $feedback = [];
+        $length   = strlen( $password );
+
+        // Length scoring
+        if ( $length >= 8 ) {
+            $score++;
+        } else {
+            $feedback[] = 'Add more characters to strengthen your password.';
+        }
+
+        if ( $length >= 12 ) {
+            $score++;
+        }
+
+        // Character variety
+        $hasLower  = preg_match( '/[a-z]/', $password );
+        $hasUpper  = preg_match( '/[A-Z]/', $password );
+        $hasNumber = preg_match( '/[0-9]/', $password );
+        $hasSymbol = preg_match( '/[^A-Za-z0-9]/', $password );
+
+        $variety = $hasLower + $hasUpper + $hasNumber + $hasSymbol;
+
+        if ( $variety >= 3 ) {
+            $score++;
+        } elseif ( $variety < 2 ) {
+            $feedback[] = 'Use a mix of uppercase, lowercase, numbers, and symbols.';
+        }
+
+        if ( 4 === $variety && $length >= 12 ) {
+            $score++;
+        }
+
+        // Unique characters
+        $uniqueChars = count( array_unique( str_split( $password ) ) );
+        if ( $uniqueChars < 5 ) {
+            $feedback[] = 'Avoid repeating characters.';
+        }
+
+        // Cap at 4
+        $score = min( 4, $score );
+
+        $labels = ['Very Weak', 'Weak', 'Fair', 'Strong', 'Very Strong'];
+
+        // Estimate crack time based on score
+        $crackTimes = [
+            'instantly',
+            'minutes',
+            'hours',
+            'days',
+            'centuries',
+        ];
+
+        return [
+            'score'     => $score,
+            'label'     => $labels[ $score ],
+            'crackTime' => $crackTimes[ $score ],
+            'feedback'  => $feedback,
+        ];
+    }
+}

--- a/src/TwoFactor/Contracts/TwoFactorProvider.php
+++ b/src/TwoFactor/Contracts/TwoFactorProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Two-Factor Provider Interface
+ *
+ * Defines the contract for all two-factor authentication providers, ensuring
+ * they implement a consistent API for generating challenges and verifying codes.
+ *
+ * @link       https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-security
+ *
+ * @package    ArtisanPackUI\Security
+ * @subpackage ArtisanPackUI\Security\TwoFactor\Contracts
+ *
+ * @since      1.2.0
+ */
+
+namespace ArtisanPackUI\SecurityAuth\TwoFactor\Contracts;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+
+/**
+ * Interface for a two-factor authentication provider.
+ *
+ * @since 1.2.0
+ */
+interface TwoFactorProvider
+{
+	/**
+	 * Generate and dispatch a two-factor authentication challenge to the user.
+	 *
+	 * For email, this sends the code. For an authenticator app, this method
+	 * might not need to do anything as the challenge is ongoing.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param Authenticatable $user The user to send the challenge to.
+	 *
+	 * @return void
+	 */
+	public function generateChallenge( Authenticatable $user ): void;
+
+	/**
+	 * Verify a given two-factor authentication code.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param Authenticatable $user The user attempting to verify.
+	 * @param string          $code The code provided by the user.
+	 *
+	 * @return bool True if the code is valid, false otherwise.
+	 */
+	public function verify( Authenticatable $user, string $code ): bool;
+}

--- a/src/TwoFactor/Providers/EmailProvider.php
+++ b/src/TwoFactor/Providers/EmailProvider.php
@@ -60,7 +60,7 @@ class EmailProvider implements TwoFactorProvider
 
 		RateLimiter::hit( $key, 900 ); // Lock for 15 minutes (900 seconds)
 
-		$code = random_int( 100000, 999999 );
+		$code = (string) random_int( 100000, 999999 );
 
 		// 3. Handle Mail Failures
 		try {

--- a/src/TwoFactor/Providers/EmailProvider.php
+++ b/src/TwoFactor/Providers/EmailProvider.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Email-based Two-Factor Provider
+ *
+ * Handles two-factor authentication by generating a code, storing it in the
+ * session, and emailing it to the user.
+ *
+ * @link       https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-security
+ *
+ * @package    ArtisanPackUI\Security
+ * @subpackage ArtisanPackUI\Security\TwoFactor\Providers
+ *
+ * @since      1.2.0
+ */
+
+namespace ArtisanPackUI\SecurityAuth\TwoFactor\Providers;
+
+use ArtisanPackUI\SecurityAuth\Mail\TwoFactorCodeMailable;
+use ArtisanPackUI\SecurityAuth\TwoFactor\Contracts\TwoFactorProvider;
+use Exception;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\RateLimiter;
+use InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * Implements email-based two-factor authentication.
+ *
+ * @since 1.2.0
+ */
+class EmailProvider implements TwoFactorProvider
+{
+	/**
+	 * Generate and send a two-factor challenge to the user.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param Authenticatable $user The user to send the challenge to.
+	 *
+	 * @throws Exception If rate limit is exceeded.
+	 * @throws InvalidArgumentException If the user does not have a valid email address.
+	 * @throws RuntimeException If the email fails to send.
+	 *
+	 * @return void
+	 */
+	public function generateChallenge( Authenticatable $user ): void
+	{
+		// 1. Rate Limiting
+		$key = 'two-factor-challenge:' . $user->getAuthIdentifier();
+		if ( RateLimiter::tooManyAttempts( $key, 3 ) ) {
+			throw new Exception( 'Too many code generation attempts. Please try again later.' );
+		}
+
+		// 2. Validate Email
+		if ( ! isset( $user->email ) || ! filter_var( $user->email, FILTER_VALIDATE_EMAIL ) ) {
+			throw new InvalidArgumentException( 'User must have a valid email address for 2FA.' );
+		}
+
+		RateLimiter::hit( $key, 900 ); // Lock for 15 minutes (900 seconds)
+
+		$code = random_int( 100000, 999999 );
+
+		// 3. Handle Mail Failures
+		try {
+			Mail::to( $user->email )->send( new TwoFactorCodeMailable( $code ) );
+		} catch ( Exception $e ) {
+			// If mail fails, clear the rate limiter so the user can try again.
+			RateLimiter::clear( $key );
+			throw new RuntimeException( 'Failed to send 2FA code. Please try again.', 0, $e );
+		}
+
+		// ONLY set the session after the email has been sent successfully.
+		session( [
+					 'two_factor_code'    => $code,
+					 'two_factor_expires' => now()->addMinutes( 10 ),
+					 'two_factor_user_id' => $user->getAuthIdentifier(),
+				 ] );
+	}
+
+	/**
+	 * Verifies the provided two-factor authentication code.
+	 *
+	 * Includes rate limiting to protect against brute-force attacks.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param Authenticatable $user The user attempting to verify.
+	 * @param string          $code The 2FA code to verify.
+	 *
+	 * @return bool True if the code is valid, false otherwise.
+	 */
+	public function verify( Authenticatable $user, string $code ): bool
+	{
+		$key = 'two-factor-verify:' . $user->getAuthIdentifier();
+
+		// 1. If rate limit is exceeded, invalidate the session and block the attempt.
+		if ( RateLimiter::tooManyAttempts( $key, 5 ) ) {
+			session()->forget( [ 'two_factor_code', 'two_factor_expires', 'two_factor_user_id' ] );
+			return false;
+		}
+
+		// Pull all session data first to mitigate timing attacks.
+		$storedUserId = session( 'two_factor_user_id' );
+		$storedCode   = (string) session( 'two_factor_code' );
+		$expiry       = session( 'two_factor_expires' );
+
+		// 2. Validate all conditions.
+		if (
+			$storedUserId !== $user->getAuthIdentifier() ||
+			! $expiry || now()->isAfter( $expiry ) ||
+			! hash_equals( $storedCode, $code )
+		) {
+			// If any check fails, log the failed attempt.
+			RateLimiter::hit( $key, 900 ); // Lock for 15 minutes
+			return false;
+		}
+
+		// 3. On success, clear the session data and the rate limiter.
+		session()->forget( [ 'two_factor_code', 'two_factor_expires', 'two_factor_user_id' ] );
+		RateLimiter::clear( $key );
+
+		return true;
+	}
+}

--- a/src/TwoFactor/TwoFactorAuthenticatable.php
+++ b/src/TwoFactor/TwoFactorAuthenticatable.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * Two-Factor Authenticatable Trait
+ *
+ * Provides the necessary properties and methods to enable two-factor
+ * authentication on a user model.
+ *
+ * @link       https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-security
+ *
+ * @package    ArtisanPackUI\Security
+ * @subpackage ArtisanPackUI\Security\TwoFactor
+ *
+ * @since      1.2.0
+ */
+
+namespace ArtisanPackUI\SecurityAuth\TwoFactor;
+
+use Exception;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use PragmaRX\Google2FA\Google2FA;
+use RuntimeException;
+
+/**
+ * Provides two-factor authentication capabilities to a model.
+ *
+ * @since 1.2.0
+ *
+ * @property-read bool        $two_factor_enabled
+ * @property      string|null $two_factor_secret
+ * @property      string|null $two_factor_recovery_codes
+ * @property      string|null $two_factor_enabled_at
+ */
+trait TwoFactorAuthenticatable
+{
+	/**
+	 * Get the two_factor_enabled attribute.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return bool
+	 */
+	public function getTwoFactorEnabledAttribute(): bool
+	{
+		return $this->hasTwoFactorEnabled();
+	}
+
+	/**
+	 * Determine if two-factor authentication is enabled.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @return bool True if 2FA is enabled, false otherwise.
+	 */
+	public function hasTwoFactorEnabled(): bool
+	{
+		return ! is_null( $this->two_factor_enabled_at );
+	}
+
+	/**
+	 * Generates a new secret key for authenticator-based 2FA.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @throws Exception If secret generation or saving fails.
+	 *
+	 * @return void
+	 */
+	public function generateTwoFactorSecret(): void
+	{
+		try {
+			$google2fa = app( Google2FA::class );
+
+			$this->two_factor_secret = encrypt( $google2fa->generateSecretKey() );
+
+			if ( ! $this->save() ) {
+				throw new RuntimeException( 'Failed to save the new two-factor secret to the database.' );
+			}
+		} catch ( Exception $e ) {
+			Log::error( 'Failed to generate 2FA secret for user: ' . $this->id, [
+				'error' => $e->getMessage(),
+			] );
+
+			// Re-throw the exception so the calling code knows the operation failed.
+			throw $e;
+		}
+	}
+
+	/**
+	 * Generates new recovery codes for the user.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @throws Exception If recovery code generation or saving fails.
+	 *
+	 * @return void
+	 */
+	public function generateRecoveryCodes(): void
+	{
+		try {
+			$this->two_factor_recovery_codes = encrypt(
+				json_encode(
+					Collection::times( 8, function () {
+						return bin2hex( random_bytes( 8 ) );
+					} )->all(),
+				),
+			);
+
+			if ( ! $this->save() ) {
+				throw new RuntimeException( 'Failed to save new recovery codes to the database.' );
+			}
+		} catch ( Exception $e ) {
+			Log::error( 'Failed to generate recovery codes for user: ' . $this->id, [
+				'error' => $e->getMessage(),
+			] );
+
+			throw $e;
+		}
+	}
+}

--- a/src/TwoFactor/TwoFactorManager.php
+++ b/src/TwoFactor/TwoFactorManager.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * Two-Factor Authentication Manager
+ *
+ * Acts as a factory for resolving and managing two-factor authentication providers.
+ *
+ * @link       https://gitlab.com/jacob-martella-web-design/artisanpack-ui/artisanpack-ui-security
+ *
+ * @package    ArtisanPackUI\Security
+ * @subpackage ArtisanPackUI\Security\TwoFactor
+ *
+ * @since      1.2.0
+ */
+
+namespace ArtisanPackUI\SecurityAuth\TwoFactor;
+
+use ArtisanPackUI\SecurityAuth\TwoFactor\Contracts\TwoFactorProvider;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\App;
+use InvalidArgumentException;
+
+/**
+ * Manages two-factor authentication provider resolution.
+ *
+ * @since 1.2.0
+ *
+ * @method void generateChallenge( Authenticatable $user )
+ * @method bool verify( Authenticatable $user, string $code )
+ */
+class TwoFactorManager
+{
+	/**
+	 * The array of resolved two-factor providers.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var array
+	 */
+	protected array $providers = [];
+
+	/**
+	 * Dynamically call the default driver instance.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param string $method     The method to call.
+	 * @param array  $parameters The parameters to pass to the method.
+	 *
+	 * @return mixed
+	 */
+	public function __call( string $method, array $parameters )
+	{
+		return $this->provider()->{$method}( ...$parameters );
+	}
+
+	/**
+	 * Get a two-factor provider instance.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param string|null $name The name of the provider to resolve.
+	 *
+	 * @return TwoFactorProvider
+	 */
+	public function provider( ?string $name = null ): TwoFactorProvider
+	{
+		$name = $name ?: $this->getDefaultDriver();
+
+		if ( ! isset( $this->providers[ $name ] ) ) {
+			$this->providers[ $name ] = $this->resolve( $name );
+		}
+
+		return $this->providers[ $name ];
+	}
+
+	/**
+	 * Get the default two-factor driver name.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @throws InvalidArgumentException If a default driver is not configured.
+	 *
+	 * @return string
+	 */
+	public function getDefaultDriver(): string
+	{
+		$default = config( 'artisanpack.security-auth.two_factor.default' );
+
+		if ( is_null( $default ) ) {
+			throw new InvalidArgumentException( 'No default two-factor provider has been configured.' );
+		}
+
+		return $default;
+	}
+
+	/**
+	 * Resolve a given provider.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param string $name The name of the provider.
+	 *
+	 * @throws InvalidArgumentException If the provider is not defined, does not specify a driver, or the driver is
+	 *                                   invalid.
+	 *
+	 * @return TwoFactorProvider
+	 */
+	protected function resolve( string $name ): TwoFactorProvider
+	{
+		$config = config( "artisanpack.security-auth.two_factor.providers.{$name}" );
+
+		if ( is_null( $config ) ) {
+			throw new InvalidArgumentException( "Two-factor provider [{$name}] is not defined." );
+		}
+
+		if ( ! isset( $config['driver'] ) ) {
+			throw new InvalidArgumentException( "Two-factor provider [{$name}] does not specify a driver." );
+		}
+
+		$instance = App::make( $config['driver'] );
+
+		if ( ! $instance instanceof TwoFactorProvider ) {
+			throw new InvalidArgumentException(
+				"Driver [{$config['driver']}] for two-factor provider [{$name}] must implement the TwoFactorProvider interface.",
+			);
+		}
+
+		return $instance;
+	}
+}

--- a/tests/Concerns/ValidatesInput.php
+++ b/tests/Concerns/ValidatesInput.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Concerns;
+
+use Illuminate\Support\Facades\Validator;
+
+trait ValidatesInput
+{
+    /**
+     * Assert that the given value passes the validation rule.
+     *
+     * @param \Illuminate\Contracts\Validation\Rule $rule
+     * @param mixed $value
+     *
+     * @return void
+     */
+    public function assertValidates( $rule, $value ): void
+    {
+        $validator = Validator::make( ['field' => $value], ['field' => $rule] );
+        $this->assertTrue( $validator->passes() );
+    }
+
+    /**
+     * Assert that the given value fails the validation rule.
+     *
+     * @param \Illuminate\Contracts\Validation\Rule $rule
+     * @param mixed $value
+     *
+     * @return void
+     */
+    public function assertFailsValidation( $rule, $value ): void
+    {
+        $validator = Validator::make( ['field' => $value], ['field' => $rule] );
+        $this->assertTrue( $validator->fails() );
+    }
+}

--- a/tests/Unit/NotCompromisedTest.php
+++ b/tests/Unit/NotCompromisedTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Unit;
+
+use ArtisanPackUI\SecurityAuth\Contracts\BreachCheckerInterface;
+use ArtisanPackUI\SecurityAuth\Rules\NotCompromised;
+use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Concerns\ValidatesInput;
+use Tests\TestCase;
+
+class NotCompromisedTest extends TestCase
+{
+    use ValidatesInput;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set( 'artisanpack.security-auth.passwordSecurity.breachChecking.enabled', true );
+    }
+
+    #[Test]
+    public function it_passes_when_password_not_compromised(): void
+    {
+        $this->mockBreachChecker( 0 );
+
+        $rule = new NotCompromised();
+
+        $this->assertValidates( $rule, 'NotCompromisedPassword123!' );
+    }
+
+    #[Test]
+    public function it_fails_when_password_is_compromised(): void
+    {
+        $this->mockBreachChecker( 1000 );
+
+        $rule = new NotCompromised();
+
+        $this->assertFailsValidation( $rule, 'password123' );
+    }
+
+    #[Test]
+    public function it_respects_threshold(): void
+    {
+        // Password appears 5 times in breaches
+        $this->mockBreachChecker( 5 );
+
+        // Threshold of 10, should pass
+        $ruleWithHighThreshold = new NotCompromised( 10 );
+        $this->assertValidates( $ruleWithHighThreshold, 'Password123!' );
+
+        // Re-mock for next test
+        $this->mockBreachChecker( 5 );
+
+        // Threshold of 0 (default), should fail
+        $ruleWithNoThreshold = new NotCompromised( 0 );
+        $this->assertFailsValidation( $ruleWithNoThreshold, 'Password123!' );
+    }
+
+    #[Test]
+    public function it_passes_when_breach_checking_disabled(): void
+    {
+        Config::set( 'artisanpack.security-auth.passwordSecurity.breachChecking.enabled', false );
+
+        // Even with a compromised password, should pass when disabled
+        $this->mockBreachChecker( 10000 );
+
+        $rule = new NotCompromised();
+
+        $this->assertValidates( $rule, 'password' );
+    }
+
+    #[Test]
+    public function it_returns_detailed_message_with_count(): void
+    {
+        $this->mockBreachChecker( 12345 );
+
+        $rule = new NotCompromised();
+        $rule->passes( 'password', 'compromised' );
+
+        $message = $rule->message();
+
+        $this->assertStringContainsString( '12,345', $message );
+        $this->assertStringContainsString( 'data breach', $message );
+    }
+
+    /**
+     * Mock the breach checker service.
+     */
+    protected function mockBreachChecker( int $occurrences ): void
+    {
+        $mock = $this->createMock( BreachCheckerInterface::class );
+        $mock->method( 'check' )->willReturn( $occurrences );
+        $mock->method( 'isCompromised' )->willReturn( $occurrences > 0);
+
+        $this->app->instance( BreachCheckerInterface::class, $mock);
+    }
+}

--- a/tests/Unit/PasswordComplexityTest.php
+++ b/tests/Unit/PasswordComplexityTest.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace Tests\Unit;
+
+use ArtisanPackUI\SecurityAuth\Rules\PasswordComplexity;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Facades\Config;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Concerns\ValidatesInput;
+use Tests\TestCase;
+
+class PasswordComplexityTest extends TestCase
+{
+    use ValidatesInput;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Set default configuration
+        Config::set( 'artisanpack.security-auth.passwordSecurity.complexity', [
+            'minLength'                    => 8,
+            'maxLength'                    => 128,
+            'requireUppercase'             => true,
+            'requireLowercase'             => true,
+            'requireNumbers'               => true,
+            'requireSymbols'               => true,
+            'minUniqueCharacters'          => 4,
+            'disallowRepeatingCharacters'  => 3,
+            'disallowSequentialCharacters' => 3,
+            'disallowUserAttributes'       => true,
+        ] );
+    }
+
+    #[Test]
+    public function it_validates_minimum_length(): void
+    {
+        $rule = new PasswordComplexity();
+
+        // Too short
+        $this->assertFailsValidation( $rule, 'Aa1!' );
+
+        // Exactly minimum length - need to avoid sequences
+        $this->assertValidates( $rule, 'Xpwd12!@' );
+    }
+
+    #[Test]
+    public function it_validates_maximum_length(): void
+    {
+        Config::set( 'artisanpack.security-auth.passwordSecurity.complexity.maxLength', 20 );
+
+        $rule = new PasswordComplexity();
+
+        // Too long (21 chars)
+        $this->assertFailsValidation( $rule, 'Xpwdxpwdxpwdxpwd12!@#' );
+
+        // Within limit - avoid sequences
+        $this->assertValidates( $rule, 'Xpwdxpwdxp12!@' );
+    }
+
+    #[Test]
+    public function it_requires_uppercase_letter(): void
+    {
+        $rule = new PasswordComplexity();
+
+        // No uppercase
+        $this->assertFailsValidation( $rule, 'xpwdxpwd12!@' );
+
+        // Has uppercase - avoid sequences
+        $this->assertValidates( $rule, 'Xpwdxpwd12!@' );
+    }
+
+    #[Test]
+    public function it_requires_lowercase_letter(): void
+    {
+        $rule = new PasswordComplexity();
+
+        // No lowercase
+        $this->assertFailsValidation( $rule, 'XPWDXPWD12!@' );
+
+        // Has lowercase - avoid sequences
+        $this->assertValidates( $rule, 'XPWDxpwd12!@' );
+    }
+
+    #[Test]
+    public function it_requires_numbers(): void
+    {
+        $rule = new PasswordComplexity();
+
+        // No numbers
+        $this->assertFailsValidation( $rule, 'Xpwdxpwd!@#$' );
+
+        // Has numbers - avoid sequences
+        $this->assertValidates( $rule, 'Xpwdxpwd12!@' );
+    }
+
+    #[Test]
+    public function it_requires_symbols(): void
+    {
+        $rule = new PasswordComplexity();
+
+        // No symbols
+        $this->assertFailsValidation( $rule, 'Xpwdxpwd1279' );
+
+        // Has symbols - avoid sequences
+        $this->assertValidates( $rule, 'Xpwdxpwd12!@' );
+    }
+
+    #[Test]
+    public function it_requires_minimum_unique_characters(): void
+    {
+        Config::set( 'artisanpack.security-auth.passwordSecurity.complexity.minUniqueCharacters', 6 );
+
+        $rule = new PasswordComplexity();
+
+        // Not enough unique characters (only 4: X, a, 1, !)
+        $this->assertFailsValidation( $rule, 'Xaaa1111!!!!' );
+
+        // Enough unique characters (X, p, w, d, 1, 2, !, @)
+        $this->assertValidates( $rule, 'Xpwdxp12!@' );
+    }
+
+    #[Test]
+    public function it_disallows_repeating_characters(): void
+    {
+        $rule = new PasswordComplexity();
+
+        // Has 4+ repeating characters (xxxx)
+        $this->assertFailsValidation( $rule, 'Pxxxxwd12!@' );
+
+        // Only 3 repeating characters (allowed)
+        $this->assertValidates( $rule, 'Pxxxwd12!@' );
+    }
+
+    #[Test]
+    public function it_disallows_sequential_characters(): void
+    {
+        $rule = new PasswordComplexity();
+
+        // Has sequential characters (abcd = 4 sequential)
+        $this->assertFailsValidation( $rule, 'Xyzabcd12!@' );
+
+        // Has reverse sequential characters (dcba = 4 sequential)
+        $this->assertFailsValidation( $rule, 'Xyzdcba12!@' );
+
+        // Has numeric sequence (12345 = 5 sequential)
+        $this->assertFailsValidation( $rule, 'Xyz12345!@#' );
+
+        // No sequential characters (wvut is not sequential - 4 chars but non-consecutive)
+        $this->assertValidates( $rule, 'Xyzwpt12!@' );
+    }
+
+    #[Test]
+    public function it_disallows_keyboard_sequences(): void
+    {
+        $rule = new PasswordComplexity();
+
+        // Has keyboard sequence (qwert = 5 sequential on keyboard)
+        $this->assertFailsValidation( $rule, 'Xyzqwert12!@' );
+
+        // No keyboard sequence
+        $this->assertValidates( $rule, 'Xyzpmk12!@' );
+    }
+
+    #[Test]
+    public function it_disallows_user_attributes_in_password(): void
+    {
+        // Create a mock user that implements Authenticatable
+        $user = new class extends User {
+            protected $guarded = [];
+
+            public function __construct()
+            {
+                parent::__construct( [
+                    'email'    => 'johndoe@example.com',
+                    'name'     => 'JohnSmith',
+                    'username' => 'jsmith',
+                ] );
+            }
+        };
+
+        $rule = new PasswordComplexity( $user );
+
+        // Contains email local part (johndoe)
+        $this->assertFailsValidation( $rule, 'johndoe12!@XY' );
+
+        // Contains name (case-insensitive)
+        $this->assertFailsValidation( $rule, 'Johnsmith12!@XY' );
+
+        // Contains username
+        $this->assertFailsValidation( $rule, 'Jsmith12!@XYZ' );
+
+        // Doesn't contain user attributes
+        $this->assertValidates( $rule, 'Pmkqrt12!@' );
+    }
+
+    #[Test]
+    public function it_respects_disabled_requirements(): void
+    {
+        Config::set( 'artisanpack.security-auth.passwordSecurity.complexity.requireUppercase', false );
+        Config::set( 'artisanpack.security-auth.passwordSecurity.complexity.requireSymbols', false );
+        Config::set( 'artisanpack.security-auth.passwordSecurity.complexity.disallowSequentialCharacters', 0 );
+
+        $rule = new PasswordComplexity();
+
+        // No uppercase or symbols, but should pass
+        $this->assertValidates( $rule, 'abcdefgh1234' );
+    }
+
+    #[Test]
+    public function it_returns_multiple_errors(): void
+    {
+        $rule = new PasswordComplexity();
+
+        // Multiple issues: too short, no uppercase, no number, no symbol
+        $result = $rule->passes( 'password', 'abc' );
+        $errors = $rule->message();
+
+        $this->assertFalse( $result );
+        $this->assertIsArray( $errors );
+        $this->assertGreaterThan( 1, count( $errors ) );
+    }
+
+    #[Test]
+    public function it_validates_strong_password(): void
+    {
+        $rule = new PasswordComplexity();
+
+        $this->assertValidates( $rule, 'MyStr0ng!P@ssword');
+        $this->assertValidates( $rule, 'C0mplex#Pass917');
+        $this->assertValidates( $rule, 'Secur3&Unique99');
+    }
+}


### PR DESCRIPTION
## Description

First content extraction for the **Security 2.0 split** — moves every file listed for `security-auth` in `SECURITY-2.0-PLAN.md` Appendix A out of `artisanpack-ui/security` 1.x and into this dedicated package. Part of Wave 4 strand A in the orchestrator (`plans/07-ecosystem-orchestrator.md` in keystone-cms), Option 2 — extract first, slim later.

## Type of Change

- [x] New feature (adds new functionality) — first real content for this package
- [ ] Breaking change — N/A here; security 1.x still owns the same code until the slim-down PR lands

## Motivation and Context

`artisanpack-ui/security` 1.x bundled 7 feature groups in one package. The 2.0 plan splits them so apps can install only what they need. This PR extracts the **auth-focused** group: 2FA, password security, account lockout, advanced sessions.

## Changes Made

**Source migrated** (namespaces rewritten `ArtisanPackUI\\Security\\*` → `ArtisanPackUI\\SecurityAuth\\*`):

- Two-factor: `TwoFactorAuthenticatable` trait, `TwoFactorManager`, `EmailProvider`, `TwoFactorProvider` contract, `TwoFactor` facade, `TwoFactorMiddleware`, `TwoFactorCodeMailable`
- Password security: `PasswordSecurityService`, `HaveIBeenPwnedService`, `PasswordComplexity` / `PasswordHistoryRule` / `PasswordPolicy` / `NotCompromised` rules, `PasswordHistory` model, `EnforcePasswordPolicy` middleware
- Account lockout: `AccountLockoutManager`, `AccountLockout` model + interface, `AccountLocked` event, `CheckAccountLockout` middleware, `ManageAccountLockout` command
- Sessions: `AdvancedSessionManager`, `SessionSecurityInterface`, `UserSession` model, `StepUpAuthentication` middleware
- Livewire: `PasswordStrengthMeter`, `AccountLockoutStatus`, `SessionManager`, `StepUpAuthenticationModal`
- Migrations: 2FA columns, `password_history`, password security columns, `user_sessions`, `account_lockouts`

**Service provider** (`SecurityAuthServiceProvider`):
- Singletons + interface bindings for the four service groups
- Middleware aliases: `two-factor`, `password.policy`, `check.lockout`, `step-up`
- Livewire component registration (guarded by `class_exists` + `app->bound('livewire')`)
- Console command registration
- Migration loaders (root + `password/` + `authentication/` subdirs)

**Config:**
- New `config/artisanpack/security-auth.php` under the `artisanpack.security-auth.*` namespace
- Source rewritten from `artisanpack.security.*` / `security.*` → `artisanpack.security-auth.*`

**Cross-package contract:**
- `Security\\Contracts\\SecurityEventLoggerInterface` (which moves to `security-analytics` in a later wave) replaced with a minimal local `AuthEventLoggerInterface` so this package is self-contained. `security-analytics` will adapt to or re-implement this contract.

**CodeRabbit feedback applied** (3 real bugs from the migrated 1.x code):
- `TwoFactorMiddleware` — fixed infinite redirect loop when verify route is in the same middleware group
- `HaveIBeenPwnedService` — replaced `Cache::remember` (reruns loader on null) with read-then-write + fail-cache so an HIBP outage doesn't serialize 5s blocking calls into every password check
- `TwoFactorCodeMailable` — typed OTP code as `string` so leading-zero codes survive

## How Has This Been Tested?

**Testing Environment:**
- macOS 25.4
- PHP 8.4 (composer platform pinned to 8.2)

**Tests Performed:**
1. `composer test` — 24 passed (45 assertions); migrated `PasswordComplexityTest` + `NotCompromisedTest` plus scaffold smoke tests
2. `composer run lint` — php-cs-fixer + phpcs both clean
3. CodeRabbit CLI review — 29 findings; 3 high-severity bugs applied; remaining nits are pre-existing 1.x style issues out of scope for the extraction

**Comprehensive test migration is a follow-up** (`PasswordSecurityServiceTest`, `AdvancedSessionManagerTest`, `AccountLockoutManagerTest`, `HaveIBeenPwnedServiceTest`, integration tests). They reference TestUser fixtures + DB setup that need adapting to this package's TestCase.

## Documentation

- [x] README updated with package scope + sibling links
- [x] CHANGELOG seeded
- [ ] Comprehensive usage docs — follow-up

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Code passes all tests
- [x] Code has been linted
- [x] Self-review completed
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email two‑factor auth with provider manager, middleware, verification emails, UI/livewire components, and trait support
  * Enhanced password security: complexity, history, expiration, breach checking (HaveIBeenPwned), strength meter, enforcement middleware, and validation rules
  * Account lockout (user & IP) with progressive durations, admin CLI, Livewire status, models, and migrations
  * Advanced session management: device/IP binding, rotation, concurrent limits, session listing/termination, pruning
  * Step‑up authentication modal and middleware

* **Documentation**
  * README status updated to reflect initial extraction

* **Tests**
  * Unit tests for password rules and breach checking
<!-- end of auto-generated comment: release notes by coderabbit.ai -->