### PR TITLE
Release prep for v1.0.0

### DIFF
--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -1,0 +1,9 @@
+name: Auto-assign milestone
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-milestone:
+    uses: ArtisanPack-UI/.github/.github/workflows/auto-milestone.yml@main

--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   auto-milestone:
-    uses: ArtisanPack-UI/.github/.github/workflows/auto-milestone.yml@main
+    uses: ArtisanPack-UI/.github/.github/workflows/auto-milestone.yml@7329ccfac5f658e9528413eb8a8e3cc5b5a95512 # main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     name: Lint
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # v2
         with:
           php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
@@ -27,7 +27,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -53,10 +53,10 @@ jobs:
         livewire: ['3.6', '4.0']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # v2
         with:
           php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
@@ -67,7 +67,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-lw${{ matrix.livewire }}-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
         run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
 
       - name: Run PHPCS
-        continue-on-error: true
         run: ./vendor/bin/phpcs src/ database/ tests/ config/
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
-    tags:
-      - 'v*'
   pull_request:
     branches: [main]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    name: Lint
 
     steps:
       - uses: actions/checkout@v4
@@ -19,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
           coverage: none
 
@@ -37,17 +36,22 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
-      - name: Upload vendor directory
-        uses: actions/upload-artifact@v4
-        with:
-          name: vendor
-          path: vendor/
-          retention-days: 1
+      - name: Run PHP-CS-Fixer
+        run: ./vendor/bin/php-cs-fixer fix --dry-run --diff
+
+      - name: Run PHPCS
+        continue-on-error: true
+        run: ./vendor/bin/phpcs src/ database/ tests/ config/
 
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    name: Test
+    name: Test (Livewire ${{ matrix.livewire }})
+
+    strategy:
+      fail-fast: true
+      matrix:
+        livewire: ['3.6', '4.0']
 
     steps:
       - uses: actions/checkout@v4
@@ -55,7 +59,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
           coverage: none
 
@@ -67,57 +71,21 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer-
+          key: ${{ runner.os }}-composer-lw${{ matrix.livewire }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-lw${{ matrix.livewire }}-
 
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
 
+      - name: Install Livewire ${{ matrix.livewire }}
+        run: composer require livewire/livewire:"^${{ matrix.livewire }}" -W --no-interaction
+
       - name: Run Unit tests
         env:
           XDEBUG_MODE: off
-        run: php vendor/bin/pest tests/Unit --no-coverage
+        run: vendor/bin/pest tests/Unit --no-coverage
 
       - name: Run Feature tests
         env:
           XDEBUG_MODE: off
-        run: php vendor/bin/pest tests/Feature --no-coverage
-
-  release:
-    needs: test
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    name: Create Release
-
-    permissions:
-      contents: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Extract release notes from CHANGELOG
-        id: changelog
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "Extracting notes for version $VERSION"
-
-          if [ -f "CHANGELOG.md" ]; then
-            # Extract section for this version
-            NOTES=$(sed -n "/## \[$VERSION\]/,/## \[/p" CHANGELOG.md | sed '1d;$d' | sed '/^$/d')
-            if [ -z "$NOTES" ]; then
-              NOTES="Release $VERSION. See CHANGELOG.md for details."
-            fi
-          else
-            NOTES="Release $VERSION"
-          fi
-
-          # Save to file for multi-line support
-          echo "$NOTES" > release_notes.txt
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          body_path: release_notes.txt
-          generate_release_notes: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: vendor/bin/pest tests/Feature --no-coverage

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,39 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Optional: Only run on specific file changes
+    # paths:
+    #   - "src/**/*.ts"
+    #   - "src/**/*.tsx"
+    #   - "src/**/*.js"
+    #   - "src/**/*.jsx"
+
+jobs:
+  claude-review:
+    if: false # Temporarily disabled while actively developing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@99ca333651aa9a8becc279065fad21c4ef1c4494 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   claude-review:
-    if: false # Temporarily disabled while actively developing
+    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   claude-review:
-    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' }}
+    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' && github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,46 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: false # Temporarily disabled while actively developing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,7 +12,18 @@ on:
 
 jobs:
   claude:
-    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' }}
+    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' && (
+      (github.event_name == 'issue_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' &&
+       contains(github.event.review.body, '@claude') &&
+       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && github.event.action == 'assigned')
+    ) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,18 +12,21 @@ on:
 
 jobs:
   claude:
-    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' && (
-      (github.event_name == 'issue_comment' &&
-       contains(github.event.comment.body, '@claude') &&
-       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review_comment' &&
-       contains(github.event.comment.body, '@claude') &&
-       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review' &&
-       contains(github.event.review.body, '@claude') &&
-       contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
-      (github.event_name == 'issues' && github.event.action == 'assigned')
-    ) }}
+    if: >-
+      ${{
+        vars.ENABLE_CLAUDE_REVIEW == 'true' && (
+          (github.event_name == 'issue_comment' &&
+           contains(github.event.comment.body, '@claude') &&
+           contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+          (github.event_name == 'pull_request_review_comment' &&
+           contains(github.event.comment.body, '@claude') &&
+           contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+          (github.event_name == 'pull_request_review' &&
+           contains(github.event.review.body, '@claude') &&
+           contains(fromJson('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+          (github.event_name == 'issues' && github.event.action == 'assigned')
+        )
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,13 +22,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@99ca333651aa9a8becc279065fad21c4ef1c4494 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   claude:
-    if: false # Temporarily disabled while actively developing
+    if: ${{ vars.ENABLE_CLAUDE_REVIEW == 'true' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,103 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    name: Test before release
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
+          coverage: none
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run tests
+        env:
+          XDEBUG_MODE: off
+        run: vendor/bin/pest --no-coverage
+
+  release:
+    needs: test
+    runs-on: ubuntu-latest
+    name: Create Release
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+      - name: Extract release notes from CHANGELOG
+        id: changelog
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          echo "Extracting notes for version $VERSION"
+
+          if [ ! -f "CHANGELOG.md" ]; then
+            echo "body=Release v$VERSION" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Extract the section between this version header and the next version header
+          NOTES=$(awk -v ver="$VERSION" '
+            /^## \[/ {
+              if (found) exit
+              if (index($0, "[" ver "]")) { found=1; next }
+            }
+            found { print }
+          ' CHANGELOG.md)
+
+          # Remove leading/trailing blank lines
+          NOTES=$(echo "$NOTES" | sed '/./,$!d' | sed -e :a -e '/^\n*$/{$d;N;ba' -e '}')
+
+          if [ -z "$NOTES" ]; then
+            NOTES="Release v$VERSION — see CHANGELOG.md for details."
+          fi
+
+          # Write to file for multi-line support
+          echo "$NOTES" > release_notes.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: v${{ steps.version.outputs.version }}
+          body_path: release_notes.txt
+          generate_release_notes: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Packagist
+        if: success()
+        run: |
+          curl -s -X POST \
+            "https://packagist.org/api/update-package?username=${{ secrets.PACKAGIST_USERNAME }}&apiToken=${{ secrets.PACKAGIST_API_TOKEN }}" \
+            -d "{\"repository\":{\"url\":\"https://github.com/${{ github.repository }}\"}}" \
+            -H "Content-Type: application/json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           echo "Extracting notes for version $VERSION"
 
           if [ ! -f "CHANGELOG.md" ]; then
-            echo "body=Release v$VERSION" >> $GITHUB_OUTPUT
+            echo "Release v$VERSION" > release_notes.txt
             exit 0
           fi
 
@@ -97,7 +97,7 @@ jobs:
       - name: Update Packagist
         if: success()
         run: |
-          curl -s -X POST \
+          curl --fail-with-body --show-error --retry 3 --retry-delay 2 --max-time 30 -X POST \
             "https://packagist.org/api/update-package?username=${{ secrets.PACKAGIST_USERNAME }}&apiToken=${{ secrets.PACKAGIST_API_TOKEN }}" \
             -d "{\"repository\":{\"url\":\"https://github.com/${{ github.repository }}\"}}" \
             -H "Content-Type: application/json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
     name: Test before release
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@8358ee0e2e8afe63c2fb8253d1d52085811ab1e5 # v2
         with:
           php-version: '8.4'
           extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite
@@ -26,7 +26,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -49,7 +49,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Extract version from tag
         id: version
@@ -86,7 +86,7 @@ jobs:
           echo "$NOTES" > release_notes.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           name: v${{ steps.version.outputs.version }}
           body_path: release_notes.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,35 @@
 # ArtisanPack UI — Security Auth Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased]
 
 ### Added
-- Initial package scaffold extracted from `package-blueprint`.
-- `artisanpack-ui/code-style` and `artisanpack-ui/code-style-pint` wired up for linting.
+
+- Initial release of the standalone Security Auth package, extracted from `artisanpack-ui/security` 1.x as part of the Security 2.0 package split.
+- **Two-factor authentication**: `TwoFactor` Facade, `TwoFactorManager`, `EmailProvider` (default), `TwoFactorAuthenticatable` trait for User models, `TwoFactorCodeMailable` for email delivery.
+- **Password security**: `PasswordSecurityService` (308 lines) for complexity validation, history enforcement, HaveIBeenPwned breach checks, and expiration tracking. Backed by `HaveIBeenPwnedService` (136 lines) for the breach lookups.
+- **Validation rules**: `PasswordComplexity`, `NotCompromised`, `PasswordHistoryRule`, `PasswordPolicy` (composite).
+- **Account lockout**: `AccountLockoutManager` (432 lines) supporting user-level and IP-level lockouts with configurable durations, failed-attempt tracking, and historical lockout audit.
+- **Advanced session management**: `AdvancedSessionManager` (415 lines) for session bindings (IP + UA), session rotation, concurrent session limits, and programmatic termination.
+- **Middleware aliases**: `two-factor`, `password.policy`, `check.lockout`, `step-up`.
+- **Livewire components** (4): `PasswordStrengthMeter`, `AccountLockoutStatus`, `SessionManager`, `StepUpAuthenticationModal` — all with shipped Blade views in plain HTML + Tailwind.
+- **Eloquent models** (3): `AccountLockout`, `PasswordHistory`, `UserSession`.
+- **Migrations** (3 groups): adds `two_factor_secret`, `two_factor_recovery_codes`, `two_factor_enabled_at` columns to `users`; password history table + extra password security columns on `users`; user sessions + account lockouts tables.
+- **Artisan command**: `security:lockout` for managing lockouts (list / lock / unlock / clear).
+- **Event**: `AccountLocked`.
+- **Service contracts**: `AccountLockoutInterface`, `SessionSecurityInterface`, `PasswordSecurityServiceInterface`, `BreachCheckerInterface`, `AuthEventLoggerInterface` for swapping implementations.
+
+### Fixed
+
+- Wrote the 4 missing Livewire Blade views (`password-strength-meter`, `account-lockout-status`, `session-manager`, `step-up-authentication-modal`) — without them every Livewire render threw `View not found` in production.
+- Added view-render smoke tests for each Livewire component to prevent regression.
+- Author email normalized to `support@artisanpackui.dev`.
+- License switched from GPL-3.0-or-later to MIT to match the rest of the ecosystem.
+
+### Removed
+
+- This package contains the auth security content previously bundled in `artisanpack-ui/security` 1.x. See the [`artisanpack-ui/security` UPGRADE guide](https://github.com/ArtisanPack-UI/security/blob/main/UPGRADE.md) for migration instructions from 1.x.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-05-18
+
 ### Added
 
 - Initial release of the standalone Security Auth package, extracted from `artisanpack-ui/security` 1.x as part of the Security 2.0 package split.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to ArtisanPack UI
 
-As an open source project, ArtisanPack UI is open to contributions from everyone. You don't need to be a developer to contribute. Whether it's contributing code, writing documentation, testing the CMS or anything in between there's a place for you here to contribute.
+As an open source project, ArtisanPack UI is open to contributions from everyone. You don't need to be a developer to contribute. Whether it's contributing code, writing documentation, testing the packages, or anything in between, there's a place for you here to contribute.
 
 ## Table of Contents
 
@@ -21,8 +21,8 @@ In order to make this a best place for everyone to contribute, there are some ha
 
 * ArtisanPack UI is open to everyone no matter your race, ethnicity, gender, who you love, etc. In order to keep it that way, there's zero tolerance for any racist, misogynistic, xenophobic, bigoted, Zionist, antisemitic (yes, there is a difference), Islamophobic, etc. messages. This includes messages sent to a fellow contributor outside of this repository. In short, don't be a jerk. Failure to comply will result in a ban from the project.
 * Be respectful when communicating with fellow contributors.
-* Respect the decisions made for what to include in the CMS.
-* Work together to create the best possible content management system.
+* Respect the decisions made for what to include in the package.
+* Work together to create the best possible developer toolkit.
 
 ## Ways to Contribute
 
@@ -31,7 +31,7 @@ There are a ton of different ways to contribute to ArtisanPack UI even if you're
 * Write code for ArtisanPack UI core
 * Create plugins to extend ArtisanPack UI
 * Create themes to add designs for ArtisanPack UI
-* Test and report bugs found in the CMS
+* Test and report bugs found in the packages
 * Write documentation
 * Write tutorials and talk about ArtisanPack UI on your blog and/or social media profiles
 * Review pull/merge requests
@@ -44,7 +44,7 @@ There are a ton of different ways to contribute to ArtisanPack UI even if you're
 
 Before contributing, make sure you have:
 - Git installed on your machine
-- PHP 8.1 or higher
+- PHP 8.2 or higher
 - Composer
 - A GitLab, GitHub, or other Git hosting account
 
@@ -465,7 +465,7 @@ Similar to GitHub process:
 
 5. **Submit patch**
    - Create GitLab issue (no account needed via email)
-   - Or email patch to: [your email or link to contribution email]
+   - Or email patch to: support@artisanpackui.dev
    - Describe changes in issue/email
    - Attach `.patch` file
 
@@ -547,7 +547,7 @@ To keep things consistent across the code base, it's important to follow these n
 
 Follow conventional commit format:
 
-```
+```text
 type: Short description
 
 Longer description if needed.
@@ -565,7 +565,7 @@ Closes #123
 - `chore:` - Maintenance tasks
 
 **Examples:**
-```
+```text
 feat: Add dark mode support
 
 Implements dark mode theme with toggle in settings.
@@ -574,7 +574,7 @@ Includes proper color contrast for accessibility.
 Closes #456
 ```
 
-```
+```text
 fix: Resolve navigation menu overlap on mobile
 
 Menu was overlapping content on screens < 768px.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,10 @@ In order to make this a best place for everyone to contribute, there are some ha
 
 There are a ton of different ways to contribute to ArtisanPack UI even if you're not a developer. Here are some (but not all) of the ways you can contribute to the project:
 
-* Write code for ArtisanPack UI core
-* Create plugins to extend ArtisanPack UI
-* Create themes to add designs for ArtisanPack UI
-* Test and report bugs found in the packages
+* Write code for the package
+* Build integrations or extensions on top of the package
+* Improve the package's tests, docs, and examples
+* Test and report bugs found in the package
 * Write documentation
 * Write tutorials and talk about ArtisanPack UI on your blog and/or social media profiles
 * Review pull/merge requests
@@ -196,7 +196,7 @@ Use this for most MRs. It includes:
 - Description of changes
 - Type of change (Bug fix, Feature, Enhancement, etc.)
 - Testing performed
-- **Accessibility tests** (required for all UI changes)
+- **Tests for the change** (unit and/or feature; required for code changes)
 - Tests added
 - Documentation updates
 - Pre-submission checklist
@@ -278,10 +278,9 @@ Labels that indicate importance:
 ### Area Labels (Where)
 
 Labels that indicate affected code area:
-- `Area::Frontend` - UI/client-side code
-- `Area::Backend` - Server/API code
-- `Area::Design` - Visual design work
-- `Area::Infrastructure` - DevOps/deployment
+- `Area::Core` - Core package logic
+- `Area::Integration` - Integration with Laravel framework / sibling packages
+- `Area::Infrastructure` - DevOps/deployment / CI
 - `Area::Testing` - Test-related work
 
 ### Special Labels
@@ -336,8 +335,8 @@ ArtisanPack UI is primarily hosted on GitLab, but you can contribute from any Gi
 
 2. **Clone your fork**
    ```bash
-   git clone git@gitlab.com:your-username/artisanpack-ui-package.git
-   cd artisanpack-ui-package
+   git clone git@gitlab.com:your-username/package-name.git
+   cd package-name
    ```
 
 3. **Add upstream remote**

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The four shipped Blade views render in plain HTML + Tailwind. Publish + override
 
 | Package | Scope |
 |---|---|
+| [`artisanpack-ui/security-full`](https://github.com/ArtisanPack-UI/security-full) | Meta-package — pulls in the full security suite (all six packages below) in a single require |
 | [`artisanpack-ui/security`](https://github.com/ArtisanPack-UI/security) | Core: input sanitization, escaping, CSP, security headers |
 | [`artisanpack-ui/security-advanced-auth`](https://github.com/ArtisanPack-UI/security-advanced-auth) | WebAuthn, SSO, social login, biometric, device fingerprinting |
 | [`artisanpack-ui/rbac`](https://github.com/ArtisanPack-UI/rbac) | Roles, permissions, Gate integration |

--- a/README.md
+++ b/README.md
@@ -1,40 +1,134 @@
 # ArtisanPack UI — Security Auth
 
-Authentication security for Laravel: two-factor authentication (email/TOTP), password complexity and breach checking, account lockout, and session management.
+Authentication security for Laravel: two-factor authentication (email + TOTP), password complexity rules, HaveIBeenPwned breach checking, password history, account lockout, advanced session management, and step-up authentication.
 
 This package is part of the **ArtisanPack UI Security 2.0** split — the auth-focused features previously bundled inside `artisanpack-ui/security` (1.x) live here in 2.0+.
 
-> **Status:** initial extraction. Source files are migrated from `artisanpack-ui/security` 1.x. Comprehensive test coverage migration is a follow-up — see open issues.
+## Features
+
+- **Two-factor authentication** — `TwoFactor` Facade with `EmailProvider` (default) and Google2FA-backed TOTP. Trait `TwoFactorAuthenticatable` for User models. `TwoFactorCodeMailable` for email delivery.
+- **Password security** (`PasswordSecurityService`) — complexity rules, breach checking via HaveIBeenPwned, history enforcement, expiration tracking. Drop-in `Rule` classes: `PasswordComplexity`, `NotCompromised`, `PasswordHistoryRule`, `PasswordPolicy`.
+- **Account lockout** (`AccountLockoutManager`) — user-level and IP-level lockouts with configurable durations, failed-attempt tracking, lockout history.
+- **Advanced session management** (`AdvancedSessionManager`) — session bindings (IP / UA), concurrent session limits, session rotation, programmatic termination.
+- **Middleware** — `two-factor`, `password.policy`, `check.lockout`, `step-up`.
+- **Livewire components** — `PasswordStrengthMeter`, `AccountLockoutStatus`, `SessionManager`, `StepUpAuthenticationModal` with shipped Blade views (plain HTML + Tailwind, no `livewire-ui-components` dep).
+- **Eloquent models** — `AccountLockout`, `PasswordHistory`, `UserSession`.
+- **Migrations** — adds 2FA columns to `users`, plus tables for password history, user sessions, and account lockouts.
+- **Artisan command** — `security:lockout` (manage account lockouts: list, lock, unlock, clear).
+- **Events** — `AccountLocked`.
 
 ## Installation
 
 ```bash
 composer require artisanpack-ui/security-auth
+php artisan migrate
 ```
 
-## Scope
+> **Note:** the bundled migrations assume the standard Laravel `users` table exists. If you're adding this package to an app without one, run Laravel's default migrations first.
 
-Once content extraction lands, this package will provide:
+(Optional) Publish the config:
 
-- Two-factor authentication (`TwoFactor` facade, email + TOTP providers)
-- Password security (complexity rules, history, HaveIBeenPwned breach checks)
-- Account lockout management
-- Advanced session management
-- Livewire components: `PasswordStrengthMeter`, `AccountLockoutStatus`, `SessionManager`, `StepUpAuthenticationModal`
-- Middleware: `TwoFactorMiddleware`, `CheckAccountLockout`
+```bash
+php artisan vendor:publish --tag=security-auth-config
+```
+
+## Quick start
+
+### Enable 2FA on a User model
+
+```php
+use ArtisanPackUI\SecurityAuth\TwoFactor\TwoFactorAuthenticatable;
+
+class User extends Authenticatable
+{
+    use TwoFactorAuthenticatable;
+}
+```
+
+```php
+use ArtisanPackUI\SecurityAuth\Facades\TwoFactor;
+
+// Generate secret + recovery codes (e.g. during 2FA setup)
+$user->generateTwoFactorSecret();
+$user->generateRecoveryCodes();
+
+// Verify a code (e.g. during login challenge)
+if ( TwoFactor::verify( $user, $request->input('code') ) ) {
+    // success
+}
+```
+
+### Validate a password with full policy
+
+```php
+use ArtisanPackUI\SecurityAuth\Rules\PasswordPolicy;
+
+$request->validate([
+    'password' => ['required', 'confirmed', new PasswordPolicy],
+]);
+```
+
+`PasswordPolicy` is a composite that runs complexity + breach check + history checks together. Use individual rules (`PasswordComplexity`, `NotCompromised`, `PasswordHistoryRule`) for finer control.
+
+### Apply middleware
+
+```php
+Route::middleware('two-factor')->group(function (): void {
+    // routes requiring valid 2FA
+});
+
+Route::middleware('check.lockout')->group(function (): void {
+    // routes that should refuse locked accounts
+});
+
+Route::middleware('step-up')->group(function (): void {
+    // routes requiring a fresh credential challenge before access
+});
+```
+
+### Mount a Livewire component
+
+```blade
+<livewire:password-strength-meter wire:model="password" />
+<livewire:account-lockout-status />
+<livewire:session-manager />
+<livewire:step-up-authentication-modal />
+```
+
+The four shipped Blade views render in plain HTML + Tailwind. Publish + override to customize.
+
+## Documentation
+
+- [Documentation home](docs/home.md)
+- [Getting started](docs/getting-started.md)
+- [Installation](docs/installation.md)
+- [Usage](docs/usage.md)
+- [Advanced](docs/advanced.md)
+- [FAQ](docs/faq.md)
+- [Troubleshooting](docs/troubleshooting.md)
+- [Changelog](CHANGELOG.md)
+
+## Requirements
+
+- PHP 8.2+
+- Laravel 10 / 11 / 12
+- `pragmarx/google2fa-laravel: ^2.3` (pulled in automatically) for TOTP 2FA
 
 ## Sibling packages
 
 | Package | Scope |
 |---|---|
-| [`artisanpack-ui/security`](https://github.com/ArtisanPack-UI/security) | Core: input sanitization, output escaping, KSES, CSP, security headers |
+| [`artisanpack-ui/security`](https://github.com/ArtisanPack-UI/security) | Core: input sanitization, escaping, CSP, security headers |
 | [`artisanpack-ui/security-advanced-auth`](https://github.com/ArtisanPack-UI/security-advanced-auth) | WebAuthn, SSO, social login, biometric, device fingerprinting |
-| [`artisanpack-ui/rbac`](https://github.com/ArtisanPack-UI/rbac) | Roles, permissions, hierarchy, Blade directives, Gate integration |
-| [`artisanpack-ui/secure-uploads`](https://github.com/ArtisanPack-UI/secure-uploads) | File validation, malware scanning, secure storage |
+| [`artisanpack-ui/rbac`](https://github.com/ArtisanPack-UI/rbac) | Roles, permissions, Gate integration |
+| [`artisanpack-ui/secure-uploads`](https://github.com/ArtisanPack-UI/secure-uploads) | File validation, malware scanning, signed-URL serving |
 | [`artisanpack-ui/security-analytics`](https://github.com/ArtisanPack-UI/security-analytics) | Event logging, anomaly detection, SIEM, dashboards |
 | [`artisanpack-ui/compliance`](https://github.com/ArtisanPack-UI/compliance) | GDPR / CCPA / LGPD compliance tools |
-| [`artisanpack-ui/security-full`](https://github.com/ArtisanPack-UI/security-full) | Meta-package bundling all of the above |
+
+## License
+
+MIT — see [LICENSE](LICENSE).
 
 ## Contributing
 
-As an open source project, this package is open to contributions from anyone. Please [read through the contributing guidelines](CONTRIBUTING.md) to learn more about how you can contribute to this project.
+Please read the [contributing guidelines](CONTRIBUTING.md) before opening an issue or PR.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Authentication security for Laravel — two-factor authentication (email/TOTP), password complexity and breach checking, account lockout, and session management.",
   "type": "library",
   "license": "MIT",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "keywords": [
     "laravel",
     "security",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "artisanpack-ui/security-auth",
   "description": "Authentication security for Laravel — two-factor authentication (email/TOTP), password complexity and breach checking, account lockout, and session management.",
   "type": "library",
-  "license": "GPL-3.0-or-later",
+  "license": "MIT",
   "version": "0.1.0",
   "keywords": [
     "laravel",
@@ -30,7 +30,7 @@
   "authors": [
     {
       "name": "Jacob Martella",
-      "email": "me@jacobmartella.com"
+      "email": "support@artisanpackui.dev"
     }
   ],
   "require": {

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,14 @@
+---
+title: Advanced
+---
+
+# Advanced
+
+Topics beyond day-to-day usage.
+
+## Topics
+
+- [Custom 2FA providers](advanced/custom-2fa-providers.md)
+- [Custom password rules](advanced/custom-password-rules.md)
+- [Custom breach checker](advanced/custom-breach-checker.md)
+- [Extending the lockout manager](advanced/extending-lockout.md)

--- a/docs/advanced/custom-2fa-providers.md
+++ b/docs/advanced/custom-2fa-providers.md
@@ -1,0 +1,103 @@
+---
+title: Custom 2FA Providers
+---
+
+# Custom 2FA Providers
+
+Implement `TwoFactorProvider` to add a new verification method (SMS, hardware key challenge wrappers, custom OTP service, etc.):
+
+```php
+namespace ArtisanPackUI\SecurityAuth\TwoFactor\Contracts;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+
+interface TwoFactorProvider
+{
+    public function getName(): string;
+    public function sendChallenge( Authenticatable $user ): void;
+    public function verify( Authenticatable $user, string $code ): bool;
+}
+```
+
+## Example: SMS via Twilio
+
+```php
+namespace App\SecurityAuth\TwoFactor;
+
+use ArtisanPackUI\SecurityAuth\TwoFactor\Contracts\TwoFactorProvider;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\Cache;
+use Twilio\Rest\Client;
+
+class SmsProvider implements TwoFactorProvider
+{
+    public function __construct(
+        protected Client $twilio,
+        protected string $fromNumber,
+    ) {}
+
+    public function getName(): string
+    {
+        return 'sms';
+    }
+
+    public function sendChallenge( Authenticatable $user ): void
+    {
+        $code = str_pad( (string) random_int( 0, 999_999 ), 6, '0', STR_PAD_LEFT );
+
+        Cache::put( $this->cacheKey( $user ), $code, now()->addMinutes( 5 ) );
+
+        $this->twilio->messages->create( $user->phone_number, [
+            'from' => $this->fromNumber,
+            'body' => "Your verification code: {$code}",
+        ] );
+    }
+
+    public function verify( Authenticatable $user, string $code ): bool
+    {
+        $expected = Cache::pull( $this->cacheKey( $user ) );
+
+        return $expected !== null && hash_equals( $expected, trim( $code ) );
+    }
+
+    protected function cacheKey( Authenticatable $user ): string
+    {
+        return "2fa_sms:{$user->getAuthIdentifier()}";
+    }
+}
+```
+
+## Registering the provider
+
+```php
+use ArtisanPackUI\SecurityAuth\TwoFactor\TwoFactorManager;
+use App\SecurityAuth\TwoFactor\SmsProvider;
+use Twilio\Rest\Client;
+
+$this->app->afterResolving( TwoFactorManager::class, function ( TwoFactorManager $manager ): void {
+    $manager->extend( new SmsProvider(
+        twilio: new Client( config('services.twilio.sid'), config('services.twilio.token') ),
+        fromNumber: config('services.twilio.from'),
+    ) );
+} );
+```
+
+Now usable:
+
+```php
+TwoFactor::provider('sms')->sendChallenge( $user );
+TwoFactor::provider('sms')->verify( $user, $code );
+```
+
+To make SMS the default:
+
+```php
+'two_factor' => ['default_provider' => 'sms'],
+```
+
+## Conventions
+
+- **Don't store secrets in plaintext.** If your provider keeps state (codes, salts, etc.), use `Cache` with a TTL, not the DB.
+- **Hash-compare codes.** `hash_equals` over `===` to avoid timing attacks.
+- **Single-use codes.** `Cache::pull()` rather than `Cache::get()` so a verified code can't be replayed.
+- **Rate limit `sendChallenge`.** Each call costs you money (Twilio, etc.) and a stream of requests could be abused. Wrap with Laravel's `RateLimiter`.

--- a/docs/advanced/custom-breach-checker.md
+++ b/docs/advanced/custom-breach-checker.md
@@ -1,0 +1,69 @@
+---
+title: Custom Breach Checker
+---
+
+# Custom Breach Checker
+
+`BreachCheckerInterface` is the contract — replace `HaveIBeenPwnedService` to point at a different breach data source (an internal feed, an enterprise security service, or a self-hosted HIBP clone).
+
+```php
+namespace ArtisanPackUI\SecurityAuth\Contracts;
+
+interface BreachCheckerInterface
+{
+    public function check( string $password ): int;        // count of breach occurrences
+    public function isCompromised( string $password ): bool;
+}
+```
+
+## Example: internal blocklist + HIBP fallback
+
+```php
+namespace App\Services;
+
+use ArtisanPackUI\SecurityAuth\Contracts\BreachCheckerInterface;
+use ArtisanPackUI\SecurityAuth\Services\HaveIBeenPwnedService;
+
+class LayeredBreachChecker implements BreachCheckerInterface
+{
+    public function __construct(
+        protected HaveIBeenPwnedService $hibp,
+        protected array $internalBlocklist,
+    ) {}
+
+    public function check( string $password ): int
+    {
+        // Internal blocklist hits dominate — return a high count to ensure isCompromised() is true.
+        if ( in_array( $password, $this->internalBlocklist, true ) ) {
+            return 1_000_000;
+        }
+
+        return $this->hibp->check( $password );
+    }
+
+    public function isCompromised( string $password ): bool
+    {
+        return $this->check( $password ) > 0;
+    }
+}
+```
+
+## Registering
+
+```php
+$this->app->bind(
+    \ArtisanPackUI\SecurityAuth\Contracts\BreachCheckerInterface::class,
+    fn ( $app ) => new \App\Services\LayeredBreachChecker(
+        hibp: $app->make( \ArtisanPackUI\SecurityAuth\Services\HaveIBeenPwnedService::class ),
+        internalBlocklist: config('security.password_blocklist', []),
+    ),
+);
+```
+
+`PasswordSecurityService` and `NotCompromised` both resolve `BreachCheckerInterface` from the container, so your implementation is used everywhere.
+
+## Conventions
+
+- **k-anonymity for any external API.** If you proxy to a third-party service, don't send the plaintext password — send a hash prefix as HIBP does. The shipped `HaveIBeenPwnedService` is the reference implementation.
+- **Cache results.** Even fast lookups add latency; cache by hash for a few hours to absorb password-set bursts.
+- **Fail open vs closed.** When the upstream is down, decide deliberately: return 0 (fail open — let the password through with a logged warning) vs throw (fail closed — block the set). Most apps want fail-open with monitoring on the failure rate.

--- a/docs/advanced/custom-password-rules.md
+++ b/docs/advanced/custom-password-rules.md
@@ -1,0 +1,84 @@
+---
+title: Custom Password Rules
+---
+
+# Custom Password Rules
+
+For checks outside the shipped policy, write a normal Laravel rule:
+
+```php
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class NoCompanyName implements ValidationRule
+{
+    public function validate( string $attribute, mixed $value, Closure $fail ): void
+    {
+        $companyName = config('app.name');
+
+        if ( stripos( $value, $companyName ) !== false ) {
+            $fail( "The password may not contain the company name." );
+        }
+    }
+}
+```
+
+Drop it alongside the package's rules:
+
+```php
+'password' => [
+    'required',
+    'confirmed',
+    new PasswordPolicy,
+    new \App\Rules\NoCompanyName,
+],
+```
+
+## Adding to the composite
+
+To make a custom rule run as part of `PasswordPolicy` automatically, override the binding:
+
+```php
+namespace App\Rules;
+
+use ArtisanPackUI\SecurityAuth\Rules\PasswordPolicy as BasePolicy;
+use Closure;
+
+class CompanyPasswordPolicy extends BasePolicy
+{
+    public function validate( string $attribute, mixed $value, Closure $fail ): void
+    {
+        parent::validate( $attribute, $value, $fail );
+        ( new NoCompanyName )->validate( $attribute, $value, $fail );
+    }
+}
+```
+
+```php
+$request->validate(['password' => ['required', new CompanyPasswordPolicy]]);
+```
+
+## Extending complexity checks
+
+`PasswordComplexity` reads its thresholds from config. To add a *new* dimension (e.g. "must contain a vowel"), subclass it:
+
+```php
+namespace App\Rules;
+
+use ArtisanPackUI\SecurityAuth\Rules\PasswordComplexity as BaseComplexity;
+use Closure;
+
+class StrictPasswordComplexity extends BaseComplexity
+{
+    public function validate( string $attribute, mixed $value, Closure $fail ): void
+    {
+        parent::validate( $attribute, $value, $fail );
+
+        if ( ! preg_match( '/[aeiou]/i', $value ) ) {
+            $fail( 'The password must contain at least one vowel.' );
+        }
+    }
+}
+```

--- a/docs/advanced/extending-lockout.md
+++ b/docs/advanced/extending-lockout.md
@@ -1,0 +1,97 @@
+---
+title: Extending the Lockout Manager
+---
+
+# Extending the Lockout Manager
+
+`AccountLockoutManager` is concrete (not interface-driven) — bound under `AccountLockoutInterface` for resolution. To customize behavior, subclass and rebind.
+
+## Common extension points
+
+### Add notification on lockout
+
+Override `lockUser()` to notify the user automatically:
+
+```php
+namespace App\Auth;
+
+use ArtisanPackUI\SecurityAuth\Authentication\Lockout\AccountLockoutManager as BaseManager;
+use ArtisanPackUI\SecurityAuth\Models\AccountLockout;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class NotifyingLockoutManager extends BaseManager
+{
+    public function lockUser(
+        Authenticatable $user,
+        string $reason,
+        string $lockoutType = 'temporary',
+        ?int $durationMinutes = null,
+        array $metadata = [],
+    ): AccountLockout {
+        $lockout = parent::lockUser( $user, $reason, $lockoutType, $durationMinutes, $metadata );
+
+        $user->notify( new \App\Notifications\AccountLocked( $lockout ) );
+
+        return $lockout;
+    }
+}
+```
+
+Register your subclass:
+
+```php
+$this->app->singleton( \ArtisanPackUI\SecurityAuth\Authentication\Lockout\AccountLockoutManager::class, NotifyingLockoutManager::class );
+$this->app->bind( \ArtisanPackUI\SecurityAuth\Authentication\Contracts\AccountLockoutInterface::class, NotifyingLockoutManager::class );
+```
+
+### Tier-based lockout durations
+
+Vary lockout duration by user tier (premium users get shorter lockouts, etc.):
+
+```php
+class TieredLockoutManager extends BaseManager
+{
+    public function lockUser(
+        Authenticatable $user,
+        string $reason,
+        string $lockoutType = 'temporary',
+        ?int $durationMinutes = null,
+        array $metadata = [],
+    ): AccountLockout {
+        $durationMinutes ??= match ( $user->tier ?? 'free' ) {
+            'enterprise' => 5,
+            'premium'    => 10,
+            default      => 30,
+        };
+
+        return parent::lockUser( $user, $reason, $lockoutType, $durationMinutes, $metadata );
+    }
+}
+```
+
+### Skip lockout for trusted IPs
+
+Override `recordFailedAttempt()` to bypass for office IPs:
+
+```php
+class TrustedIpLockoutManager extends BaseManager
+{
+    public function recordFailedAttempt(
+        string $trigger,
+        ?Authenticatable $user = null,
+        ?string $ipAddress = null,
+    ): array {
+        if ( in_array( $ipAddress, config('security.trusted_ips', []), true ) ) {
+            return ['locked' => false, 'attempts' => 0, 'remaining' => PHP_INT_MAX];
+        }
+
+        return parent::recordFailedAttempt( $trigger, $user, $ipAddress );
+    }
+}
+```
+
+## Conventions
+
+- **Preserve event firing.** The base `lockUser()` dispatches `AccountLocked`. Calling `parent::lockUser()` (rather than reimplementing) keeps the event flowing to any listeners.
+- **Return types must match.** The contract returns `AccountLockout` from lock methods; your overrides must too.
+- **Keep manager state minimal.** The base class is mostly stateless — derived state lives in the DB rows. Your overrides should match that pattern.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,57 @@
+---
+title: FAQ
+---
+
+# FAQ
+
+## Does this package require `artisanpack-ui/security`?
+
+No. Security Auth is standalone — only `artisanpack-ui/core` and `pragmarx/google2fa-laravel` get pulled in beyond standard Laravel.
+
+## Can I use TOTP without sending email?
+
+Yes. Set `two_factor.default_provider => 'google2fa'`. The email provider stays available — switch per-call with `TwoFactor::provider('email')->sendChallenge( $user )`. Or use `TwoFactor::provider('google2fa')`.
+
+## Does `NotCompromised` send my users' passwords to HaveIBeenPwned?
+
+No — it uses k-anonymity. Only the first 5 chars of the SHA-1 hash leave your server; HIBP returns all hashes starting with that prefix, and your server scans the response locally. The plaintext password never crosses the network.
+
+## What's the behavior when the HIBP API is unreachable?
+
+The shipped service fails open — returns 0 (not compromised) and logs a warning. This avoids blocking password sets during transient outages. To fail closed instead, subclass `HaveIBeenPwnedService::check()` to throw on connection failure and let validation reject the set.
+
+## Can I use this with Laravel Sanctum / Passport?
+
+Yes. The 2FA flow assumes a session for the challenge UX, but once verified the user's tokens work as normal. For pure API auth (no session), implement 2FA at the token-issue step rather than per-request.
+
+## What happens to active sessions when an account is locked?
+
+Existing sessions stay active by default. To force log-out on lock, listen for `AccountLocked` and call `$sessionManager->terminateAllSessions( $event->user )` from your listener.
+
+## Does account lockout protect against credential stuffing across many accounts?
+
+User-level lockout doesn't — `lockout_ip => true` adds an IP-level layer that catches the same IP hitting many usernames. For more sophisticated patterns (rotating IPs, distributed attacks), pair with `artisanpack-ui/security-analytics`'s `CredentialStuffingDetector`.
+
+## Can I use the package without Livewire?
+
+Yes. The 4 Livewire components are optional — the service surface (services, traits, rules, middleware, commands, events) works without Livewire installed. Build your own UI on top of the same APIs.
+
+## How do I migrate users from a different 2FA package?
+
+Two scenarios:
+
+- **From Laravel Fortify.** Fortify's `two_factor_secret` and `two_factor_recovery_codes` columns are compatible with this package — the trait reads/writes the same columns. After installing, existing Fortify users have working 2FA immediately.
+- **From a custom implementation.** Copy your existing secret / recovery code columns into the package's expected shape (TEXT, encrypted via Laravel's Encrypter), then `$user->two_factor_enabled_at = now()` for users who had 2FA on.
+
+## Why do the migrations require an existing `users` table?
+
+The `add_two_factor_to_users_table` migration uses `Schema::table('users', ...)` which assumes the table exists. Run Laravel's default migrations first. For long-term safety, the migration should add a `Schema::hasTable('users')` guard — tracked as issue [#7](https://github.com/ArtisanPack-UI/security-auth/issues/7).
+
+## How long should I set `freshness_minutes` for step-up?
+
+Depends on the operation's sensitivity:
+- 5 minutes — destructive actions (delete account, change email, view API tokens)
+- 15 minutes — moderately sensitive (change payment method, export data)
+- 60 minutes — light sensitivity (rename account, change profile photo)
+
+There's no universal answer — match the friction tolerance of your users against the threat model of the action.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,89 @@
+---
+title: Getting Started
+---
+
+# Getting Started
+
+Five minutes from install to a working 2FA + password policy + lockout pipeline.
+
+## 1. Install
+
+```bash
+composer require artisanpack-ui/security-auth
+php artisan migrate
+```
+
+> The migrations add columns to the `users` table. If you don't have a standard Laravel `users` table, run Laravel's default migrations first.
+
+## 2. Add the 2FA trait to your User model
+
+```php
+use ArtisanPackUI\SecurityAuth\TwoFactor\TwoFactorAuthenticatable;
+
+class User extends Authenticatable
+{
+    use TwoFactorAuthenticatable;
+}
+```
+
+## 3. Enable 2FA for a user
+
+```php
+$user->generateTwoFactorSecret();   // store secret + recovery codes on the user row
+$user->generateRecoveryCodes();
+```
+
+Show the user their secret as a QR code or recovery codes (one-time display only — re-generation invalidates prior codes).
+
+## 4. Verify 2FA at login
+
+```php
+use ArtisanPackUI\SecurityAuth\Facades\TwoFactor;
+
+if ( TwoFactor::verify( $user, $request->input('code') ) ) {
+    // success — complete login
+}
+```
+
+## 5. Apply the password policy
+
+```php
+use ArtisanPackUI\SecurityAuth\Rules\PasswordPolicy;
+
+$request->validate([
+    'password' => ['required', 'confirmed', new PasswordPolicy],
+]);
+```
+
+`PasswordPolicy` enforces complexity + breach check + history all in one rule.
+
+## 6. Gate routes with middleware
+
+```php
+Route::middleware(['auth', 'two-factor', 'check.lockout'])->group(function (): void {
+    // protected routes
+});
+
+Route::middleware(['auth', 'password.policy'])->group(function (): void {
+    // refuse access until the user's password meets current policy
+});
+
+Route::middleware('step-up')->group(function (): void {
+    // require a fresh credential before access
+});
+```
+
+## 7. Mount Livewire components for the user-facing surface
+
+```blade
+<livewire:password-strength-meter wire:model.live="password" />
+<livewire:account-lockout-status />
+<livewire:session-manager />
+<livewire:step-up-authentication-modal />
+```
+
+## Next steps
+
+- [Usage](usage.md) — per-subsystem reference
+- [Advanced](advanced.md) — extending providers, custom rules
+- [Installation](installation.md) — full config reference

--- a/docs/home.md
+++ b/docs/home.md
@@ -1,0 +1,37 @@
+---
+title: ArtisanPack UI Security Auth Documentation
+---
+
+# ArtisanPack UI Security Auth
+
+Authentication security for Laravel: two-factor auth (email + TOTP), password complexity and breach checking, account lockout, advanced session management, and step-up authentication.
+
+This package is part of the **ArtisanPack UI Security 2.0** split.
+
+## What's in this package
+
+- **Two-factor authentication** — `TwoFactor` Facade, email + TOTP providers, recovery codes, trait for User models
+- **Password security** — complexity rules, HaveIBeenPwned breach checks, history enforcement, expiration tracking
+- **Account lockout** — user + IP-level lockouts with configurable durations
+- **Session management** — bindings, rotation, concurrent limits, programmatic termination
+- **Step-up authentication** — fresh credential challenge for sensitive operations
+- **4 Livewire components** with shipped Blade views
+
+## Documentation map
+
+- [Getting Started](getting-started.md) — 5-minute path
+- [Installation](installation.md)
+- [Usage](usage.md) — per-subsystem reference
+- [Advanced](advanced.md) — extending providers, custom rules
+- [FAQ](faq.md)
+- [Troubleshooting](troubleshooting.md)
+
+## Related packages
+
+| Package | Scope |
+|---|---|
+| [`artisanpack-ui/security`](https://github.com/ArtisanPack-UI/security) | Core: sanitization, escaping, CSP, security headers |
+| [`artisanpack-ui/security-advanced-auth`](https://github.com/ArtisanPack-UI/security-advanced-auth) | WebAuthn, SSO, social login |
+| [`artisanpack-ui/rbac`](https://github.com/ArtisanPack-UI/rbac) | Roles, permissions, Gate integration |
+| [`artisanpack-ui/secure-uploads`](https://github.com/ArtisanPack-UI/secure-uploads) | File validation, malware scanning |
+| [`artisanpack-ui/security-analytics`](https://github.com/ArtisanPack-UI/security-analytics) | Event logging, anomaly detection, SIEM, dashboards |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,50 @@
+---
+title: Installation
+---
+
+# Installation
+
+## Install via Composer
+
+```bash
+composer require artisanpack-ui/security-auth
+```
+
+Auto-registers via Laravel's package discovery.
+
+## Run migrations
+
+```bash
+php artisan migrate
+```
+
+Three migration groups:
+- `add_two_factor_to_users_table` — adds `two_factor_secret`, `two_factor_recovery_codes`, `two_factor_enabled_at` columns to the existing `users` table
+- `password/` — adds password security columns to `users` + creates `password_history`
+- `authentication/` — creates `user_sessions` and `account_lockouts`
+
+> **Prerequisite**: a standard Laravel `users` table must exist before these migrations run. Run Laravel's default migrations first.
+
+## (Optional) Publish the config
+
+```bash
+php artisan vendor:publish --tag=security-auth-config
+```
+
+Lives at `config/artisanpack/security-auth.php`. Override 2FA provider, password policy thresholds, lockout durations, session bindings here.
+
+## Add the trait
+
+```php
+use ArtisanPackUI\SecurityAuth\TwoFactor\TwoFactorAuthenticatable;
+
+class User extends Authenticatable
+{
+    use TwoFactorAuthenticatable;
+}
+```
+
+## Deeper topics
+
+- [Requirements](installation/requirements.md)
+- [Configuration](installation/configuration.md)

--- a/docs/installation/configuration.md
+++ b/docs/installation/configuration.md
@@ -1,0 +1,80 @@
+---
+title: Configuration
+---
+
+# Configuration
+
+Publish the shipped config:
+
+```bash
+php artisan vendor:publish --tag=security-auth-config
+```
+
+Lives at `config/artisanpack/security-auth.php`. Key sections:
+
+## `two_factor`
+
+```php
+'two_factor' => [
+    'enabled'         => env('SECURITY_AUTH_2FA_ENABLED', true),
+    'default_provider' => env('SECURITY_AUTH_2FA_PROVIDER', 'email'),  // email | google2fa
+    'code_lifetime'    => 5,    // minutes — for email provider
+    'recovery_codes'   => [
+        'count'  => 8,
+        'length' => 10,
+    ],
+],
+```
+
+Switch `default_provider` to `google2fa` for TOTP (Google Authenticator, Authy, 1Password, etc.). Email provider is simpler to deploy but less secure.
+
+## `password_security`
+
+```php
+'password_security' => [
+    'min_length'         => 12,
+    'require_uppercase'  => true,
+    'require_lowercase'  => true,
+    'require_numbers'    => true,
+    'require_symbols'    => true,
+    'history_count'      => 5,         // previous N passwords blocked
+    'breach_check'       => true,      // HIBP lookup on every set
+    'expire_after_days'  => 90,        // 0 to disable
+],
+```
+
+## `account_lockout`
+
+```php
+'account_lockout' => [
+    'enabled'             => true,
+    'max_attempts'        => 5,
+    'lockout_minutes'     => 15,
+    'attempts_window'     => 5,        // minutes
+    'lockout_ip'          => true,     // also lock the IP, not just the user
+    'ip_lockout_minutes'  => 60,
+],
+```
+
+## `sessions`
+
+```php
+'sessions' => [
+    'enabled'                  => true,
+    'bind_to_ip'               => false,   // strict — terminate on IP change
+    'bind_to_user_agent'       => false,   // strict — terminate on UA change
+    'max_concurrent'           => 0,        // 0 = no limit
+    'rotate_on_privilege_change' => true,
+    'idle_timeout_minutes'     => 60,
+],
+```
+
+## `step_up`
+
+```php
+'step_up' => [
+    'enabled'                 => true,
+    'freshness_minutes'       => 15,    // re-challenge after this idle period
+    'available_methods'       => ['password', '2fa'],  // restrict per app needs
+],
+```

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -1,0 +1,32 @@
+---
+title: Requirements
+---
+
+# Requirements
+
+## PHP
+
+- PHP 8.2+
+
+## Laravel
+
+- Laravel 10 / 11 / 12
+
+## Composer dependencies (pulled in automatically)
+
+- `artisanpack-ui/core: ^1.0`
+- `pragmarx/google2fa-laravel: ^2.3` — backs the TOTP 2FA provider
+
+## Optional dependencies
+
+- `livewire/livewire: ^3.6 | ^4.0` — only required for the 4 Livewire components. The rest of the package (services, traits, middleware, rules) works without Livewire.
+
+## Database
+
+Any Eloquent-supported driver. The migrations alter the `users` table and create three new tables (`password_history`, `user_sessions`, `account_lockouts`).
+
+**Prerequisite**: a standard Laravel `users` table must exist before these migrations run.
+
+## Authentication system
+
+Designed against Laravel's standard auth setup — session-based login via `auth` middleware, user model implementing `Authenticatable`. Sanctum / Passport tokens are compatible but the 2FA challenge flow expects a session.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,7 +22,7 @@ Three common causes:
 
 ## `pragmarx/google2fa-laravel` missing
 
-If you see `Class 'PragmaRX\Google2FA\...' not found`, the dependency didn't install. Run `composer require pragmarx/google2fa-laravel`. The package's composer.json requires it but a `composer install` without dev deps in certain scenarios can skip it.
+If you see `Class 'PragmaRX\Google2FA\...' not found`, the dependency didn't install correctly. Run `composer require pragmarx/google2fa-laravel`, or re-run `composer install` after verifying your lockfile is current. Note: `composer install --no-dev` only skips `require-dev` packages; `pragmarx/google2fa-laravel` lives in `require`, so it should always be installed. If it's missing, suspect a stale lockfile, an interrupted install, or a platform constraint mismatch.
 
 ## Account stays locked after duration expires
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,84 @@
+---
+title: Troubleshooting
+---
+
+# Troubleshooting
+
+## `View [security-auth::livewire.*] not found`
+
+This was a 0.x bug — the 4 Livewire components didn't have shipped views. Fixed in the v1.0 release. If you still see this, you're on a pre-1.0 build.
+
+## `SQLSTATE[HY000]: General error: 1 no such table: users` when running migrations
+
+The package's `add_two_factor_to_users_table` migration assumes a `users` table exists. Run Laravel's default migrations first. Long-term fix: tracked as [#7](https://github.com/ArtisanPack-UI/security-auth/issues/7) (add `Schema::hasTable()` guards).
+
+## 2FA codes are always rejected
+
+Three common causes:
+
+1. **Clock skew (TOTP).** The TOTP code is time-based — your server clock must be within ~30s of the user's authenticator app. Sync NTP.
+2. **Wrong secret column.** If you migrated from another package, ensure `two_factor_secret` is encrypted via Laravel's Encrypter (the trait expects this).
+3. **Email provider cache TTL.** Codes expire after `two_factor.code_lifetime` minutes (default 5). Lengthen if your users routinely take longer.
+
+## `pragmarx/google2fa-laravel` missing
+
+If you see `Class 'PragmaRX\Google2FA\...' not found`, the dependency didn't install. Run `composer require pragmarx/google2fa-laravel`. The package's composer.json requires it but a `composer install` without dev deps in certain scenarios can skip it.
+
+## Account stays locked after duration expires
+
+`AccountLockoutManager::isUserLocked()` checks the lockout's `unlocks_at` against `now()`. If your server clock is wrong, locks don't expire as expected. Verify with `date` on the server.
+
+For permanent lockouts (`type=permanent`), the lockout never expires automatically — unlock manually via `security:lockout unlock --user=...` or `$lockoutManager->unlockUser($user)`.
+
+## Sessions are terminated unexpectedly
+
+If you have `bind_to_ip => true`, any IP change (mobile network swap, VPN toggle, ISP rotation) terminates the session. Either:
+- Set `bind_to_ip => false` for a friendlier UX with weaker session-hijack protection
+- Keep it on for high-security apps and live with the friction
+- Implement a "remember device" flow that whitelists specific IPs per user
+
+## Password policy rejects passwords that meet documented requirements
+
+`PasswordPolicy` is composite — check the individual rules:
+- `PasswordComplexity` thresholds in config — verify they match what you advertise to users
+- `NotCompromised` — HIBP may flag a password that's "complex enough" but appeared in a breach
+- `PasswordHistoryRule` — recently-used passwords are blocked per `password_security.history_count`
+
+Test each rule individually to identify which is rejecting.
+
+## Step-up modal doesn't open
+
+The modal listens on the `open-step-up` event. From Alpine: `@click="$wire.dispatch('open-step-up')"`. From your JS: `Livewire.dispatch('open-step-up', { redirectUrl: '...' })`. Make sure the component is mounted on the page (`<livewire:step-up-authentication-modal />`).
+
+## Tests fail with `no such table: users`
+
+Add this to your test setup:
+
+```php
+beforeEach( function (): void {
+    if ( ! Schema::hasTable( 'users' ) ) {
+        Schema::create( 'users', function ( Blueprint $table ): void {
+            $table->id();
+            $table->string( 'name' );
+            $table->string( 'email' )->unique();
+            $table->timestamp( 'email_verified_at' )->nullable();
+            $table->string( 'password' );
+            $table->rememberToken();
+            $table->timestamps();
+        } );
+    }
+
+    $this->artisan( 'migrate' );
+} );
+```
+
+The package's `tests/Feature/Livewire/ComponentRenderTest.php` uses this pattern — copy from there.
+
+## Still stuck?
+
+Open an issue at https://github.com/ArtisanPack-UI/security-auth/issues with:
+
+- PHP and Laravel versions
+- Which subsystem (2FA, password security, lockout, sessions, step-up)
+- The exact error / behavior with a minimal reproduction
+- Relevant config (with any secrets redacted)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,18 @@
+---
+title: Usage
+---
+
+# Usage
+
+Per-subsystem reference.
+
+## Topics
+
+- [Two-factor authentication](usage/two-factor.md) — `TwoFactor` Facade, providers, recovery codes
+- [Password security](usage/password-security.md) — rules, breach check, history, expiration
+- [Account lockout](usage/account-lockout.md) — user + IP lockouts, failed attempt tracking
+- [Session management](usage/session-management.md) — bindings, rotation, concurrent limits
+- [Step-up authentication](usage/step-up.md) — fresh credential challenge
+- [Middleware](usage/middleware.md) — `two-factor`, `password.policy`, `check.lockout`, `step-up`
+- [Livewire components](usage/livewire-components.md) — 4 shipped components + view customization
+- [Artisan commands](usage/artisan-commands.md) — `security:lockout`

--- a/docs/usage/account-lockout.md
+++ b/docs/usage/account-lockout.md
@@ -1,0 +1,120 @@
+---
+title: Account Lockout
+---
+
+# Account Lockout
+
+`AccountLockoutManager` (bound to `AccountLockoutInterface`) handles both user-level and IP-level lockouts driven by failed-attempt counts.
+
+## Recording a failed attempt
+
+Trigger from your login flow:
+
+```php
+use ArtisanPackUI\SecurityAuth\Authentication\Contracts\AccountLockoutInterface;
+
+$lockoutManager = app( AccountLockoutInterface::class );
+
+// On failed login
+$result = $lockoutManager->recordFailedAttempt(
+    trigger: 'login',
+    user: $user,                   // optional — pass null for anonymous attempts
+    ipAddress: $request->ip(),
+);
+
+// $result contains: ['locked' => bool, 'attempts' => int, 'remaining' => int]
+if ( $result['locked'] ) {
+    // user just hit the lockout threshold — refuse login
+}
+```
+
+If the attempt threshold is hit within the configured window, `recordFailedAttempt` automatically locks the user (and the IP if `lockout_ip` is on).
+
+## Clearing failed attempts
+
+On successful login, clear the counter:
+
+```php
+$lockoutManager->clearFailedAttempts(
+    user: $user,
+    ipAddress: $request->ip(),
+);
+```
+
+## Manual locks
+
+```php
+$lockoutManager->lockUser(
+    user: $user,
+    reason: 'Suspicious activity detected',
+    lockoutType: 'temporary',         // temporary | permanent
+    durationMinutes: 60,
+    metadata: ['source' => 'admin'],
+);
+
+$lockoutManager->lockIp(
+    ipAddress: $ip,
+    durationMinutes: 240,
+    reason: 'Credential stuffing detected',
+);
+```
+
+## Checking lock state
+
+```php
+if ( $lockoutManager->isUserLocked( $user ) ) {
+    abort(403, 'Account locked');
+}
+
+if ( $lockoutManager->isIpLocked( $request->ip() ) ) {
+    abort(429, 'Too many failed attempts from this IP');
+}
+
+$activeLockout = $lockoutManager->getUserLockout( $user );  // ?AccountLockout
+```
+
+## Middleware
+
+`check.lockout` aborts 403 for locked users and 429 for locked IPs:
+
+```php
+Route::middleware(['auth', 'check.lockout'])->group(function (): void {
+    // gated routes
+});
+```
+
+## Lockout history
+
+Each lock writes an `AccountLockout` row. Query it directly:
+
+```php
+use ArtisanPackUI\SecurityAuth\Models\AccountLockout;
+
+AccountLockout::where('user_id', $user->id)
+    ->orderByDesc('created_at')
+    ->paginate();
+```
+
+The `AccountLockoutStatus` Livewire component surfaces this on the user's account page.
+
+## CLI
+
+```bash
+php artisan security:lockout list
+php artisan security:lockout list --user=user@example.com
+php artisan security:lockout lock --user=user@example.com --duration=60 --reason="..."
+php artisan security:lockout unlock --user=user@example.com
+php artisan security:lockout clear-attempts --user=user@example.com
+```
+
+## Events
+
+`AccountLocked` fires when a lock is applied. Subscribe to alert / notify:
+
+```php
+use ArtisanPackUI\SecurityAuth\Events\AccountLocked;
+
+Event::listen( AccountLocked::class, function ( AccountLocked $event ): void {
+    Notification::send( $event->user, new AccountLockedNotification( $event->lockout ) );
+} );
+```

--- a/docs/usage/artisan-commands.md
+++ b/docs/usage/artisan-commands.md
@@ -1,0 +1,53 @@
+---
+title: Artisan Commands
+---
+
+# Artisan Commands
+
+One shipped command: `security:lockout`. Handles all lockout management subactions.
+
+## `security:lockout list`
+
+```bash
+php artisan security:lockout list
+php artisan security:lockout list --user=user@example.com
+php artisan security:lockout list --ip=198.51.100.1
+php artisan security:lockout list --active
+php artisan security:lockout list --since=2026-05-01
+```
+
+Lists lockouts matching the filters. By default shows recent lockouts (active + cleared). `--active` shows only currently-active ones.
+
+## `security:lockout lock`
+
+```bash
+php artisan security:lockout lock --user=user@example.com --duration=60 --reason="Suspicious login pattern"
+php artisan security:lockout lock --ip=198.51.100.1 --duration=240 --reason="Credential stuffing"
+php artisan security:lockout lock --user=42 --type=permanent --reason="Account banned"
+```
+
+Applies a manual lockout. `--duration` in minutes (ignored for `type=permanent`). `--type` is `temporary` (default) or `permanent`.
+
+## `security:lockout unlock`
+
+```bash
+php artisan security:lockout unlock --user=user@example.com
+php artisan security:lockout unlock --ip=198.51.100.1
+```
+
+Clears the active lockout. Subsequent failed attempts can re-trigger automatic locks per policy.
+
+## `security:lockout clear-attempts`
+
+```bash
+php artisan security:lockout clear-attempts --user=user@example.com
+php artisan security:lockout clear-attempts --ip=198.51.100.1
+```
+
+Resets the failed-attempt counter without unlocking. Useful for clearing legitimate failed attempts (typos, password manager mismatch) without giving up the lockout protection.
+
+## Exit codes
+
+- `0` on success
+- `1` on user input error (unknown user / IP, conflicting flags)
+- `2` on system error (DB issue, etc.)

--- a/docs/usage/livewire-components.md
+++ b/docs/usage/livewire-components.md
@@ -1,0 +1,78 @@
+---
+title: Livewire Components
+---
+
+# Livewire Components
+
+Four components ship with Blade views in plain HTML + Tailwind. Each is independently usable.
+
+## `<livewire:password-strength-meter />`
+
+Real-time password strength feedback. Bind to the host form's password input:
+
+```blade
+<form>
+    <input type="password" wire:model.live="password" />
+    <livewire:password-strength-meter wire:model.live="password" />
+    <button type="submit">Save</button>
+</form>
+```
+
+Public properties:
+- `password` (string) — the password being evaluated
+- `userInputs` (array) — user identifiers to penalize as predictable (e.g. `[$user->name, $user->email]`)
+- `score` (int 0-100)
+- `label` (string — "Weak", "Fair", "Good", "Strong")
+- `crackTime` (string — human-readable estimate)
+- `feedback` (array of guidance messages)
+- `requirements` (array of policy checks with `met` flag)
+
+## `<livewire:account-lockout-status />`
+
+Shows the user's current lockout state (if any) plus paginated history.
+
+```blade
+<livewire:account-lockout-status />
+```
+
+Use on the user's account settings page or security page so they can see why they were locked previously.
+
+## `<livewire:session-manager />`
+
+Lists active sessions with terminate controls.
+
+```blade
+<livewire:session-manager />
+```
+
+Shows: device, IP, location, last activity, auth method. Each non-current session has a "Sign out" button (with confirmation). A "Sign out of all other sessions" button at the top terminates everything except the current.
+
+## `<livewire:step-up-authentication-modal />`
+
+Renders only when opened via JavaScript / Alpine:
+
+```blade
+<livewire:step-up-authentication-modal />
+
+<button @click="$wire.dispatch('open-step-up', { redirectUrl: '/account/delete' })">
+    Delete account
+</button>
+```
+
+Listens on the `open-step-up` event. On successful verification, dispatches `step-up-verified` and navigates to the supplied `redirectUrl`.
+
+## Customizing views
+
+The shipped Blade views are plain HTML + Tailwind. To customize:
+
+1. Publish them (after `php artisan vendor:publish --tag=security-auth-views` lands as a publishable group):
+   ```bash
+   php artisan vendor:publish --tag=security-auth-views
+   ```
+2. Or shadow them by placing files at `resources/views/vendor/security-auth/livewire/*.blade.php` — Laravel resolves overrides before package defaults.
+
+Common customizations:
+- Wrap in your own design-system components (`<x-card>`, `<x-button>`, etc.)
+- Swap the strength bar for a more elaborate visualization
+- Replace the inline event-detail panel with a modal
+- Customize copy / translations

--- a/docs/usage/livewire-components.md
+++ b/docs/usage/livewire-components.md
@@ -65,7 +65,7 @@ Listens on the `open-step-up` event. On successful verification, dispatches `ste
 
 The shipped Blade views are plain HTML + Tailwind. To customize:
 
-1. Publish them (after `php artisan vendor:publish --tag=security-auth-views` lands as a publishable group):
+1. Publish them with the `security-auth-views` tag:
    ```bash
    php artisan vendor:publish --tag=security-auth-views
    ```

--- a/docs/usage/middleware.md
+++ b/docs/usage/middleware.md
@@ -1,0 +1,70 @@
+---
+title: Middleware
+---
+
+# Middleware
+
+Four middleware aliases register with Laravel's router. Apply per-route or in middleware groups.
+
+## `two-factor`
+
+Requires the authenticated user to have a verified 2FA session. Redirects to the 2FA challenge route when missing.
+
+```php
+Route::middleware(['auth', 'two-factor'])->group(function (): void {
+    // Routes requiring 2FA verification this session
+});
+```
+
+If the user hasn't enabled 2FA at all, the middleware allows the request through (configurable — set `two_factor.require_enabled => true` to force enrollment first).
+
+## `password.policy`
+
+Refuses access when the user's password is expired or doesn't meet current policy. Redirects to a password change flow.
+
+```php
+Route::middleware(['auth', 'password.policy'])->group(function (): void {
+    // Routes that require an up-to-date password
+});
+```
+
+Useful for enforcing rotation: set `password_security.expire_after_days => 90` and apply this middleware to your sensitive routes.
+
+## `check.lockout`
+
+Aborts requests from locked users (403) or locked IPs (429).
+
+```php
+Route::middleware('check.lockout')->group(function (): void {
+    // Or apply to all routes via your kernel/middleware-group
+});
+```
+
+Often applied globally to the `web` group so even unauthenticated routes (e.g. login page) refuse locked IPs.
+
+## `step-up`
+
+Requires a fresh credential challenge within `freshness_minutes`. See [Step-up authentication](step-up.md).
+
+```php
+Route::middleware('step-up')->group(function (): void {
+    Route::delete('/account', [AccountController::class, 'destroy']);
+});
+```
+
+## Ordering
+
+Combine in this order when stacking:
+
+```php
+Route::middleware(['auth', 'check.lockout', 'password.policy', 'two-factor', 'step-up'])
+    ->group(function (): void {
+        // ...
+    });
+```
+
+- `auth` first — establishes the user.
+- `check.lockout` second — refuse locked before doing more work.
+- `password.policy` third — refuse stale passwords before honoring 2FA / step-up.
+- `two-factor` fourth — verified 2FA for the session.
+- `step-up` last — most expensive (interactive challenge) — only when everything else passed.

--- a/docs/usage/password-security.md
+++ b/docs/usage/password-security.md
@@ -1,0 +1,97 @@
+---
+title: Password Security
+---
+
+# Password Security
+
+`PasswordSecurityService` (bound to `PasswordSecurityServiceInterface`) is the orchestrator. Four validation rules wrap individual concerns:
+
+- `PasswordComplexity` — length, uppercase, lowercase, numbers, symbols
+- `NotCompromised` — HaveIBeenPwned breach check
+- `PasswordHistoryRule` — disallow reuse of previous N passwords
+- `PasswordPolicy` — composite of all three plus expiration check
+
+## Use the composite rule
+
+The simplest path — all checks in one rule:
+
+```php
+use ArtisanPackUI\SecurityAuth\Rules\PasswordPolicy;
+
+$request->validate([
+    'password' => ['required', 'confirmed', new PasswordPolicy],
+]);
+```
+
+## Use individual rules for finer control
+
+```php
+use ArtisanPackUI\SecurityAuth\Rules\PasswordComplexity;
+use ArtisanPackUI\SecurityAuth\Rules\NotCompromised;
+use ArtisanPackUI\SecurityAuth\Rules\PasswordHistoryRule;
+
+$request->validate([
+    'password' => [
+        'required',
+        'confirmed',
+        new PasswordComplexity,
+        new NotCompromised,
+        new PasswordHistoryRule( $user ),
+    ],
+]);
+```
+
+## Recording a new password
+
+After successful update, record it in history so future changes can't reuse it:
+
+```php
+use ArtisanPackUI\SecurityAuth\Contracts\PasswordSecurityServiceInterface;
+
+$user->password = Hash::make( $request->input('password') );
+$user->save();
+
+app( PasswordSecurityServiceInterface::class )
+    ->recordPassword( $user->password, $user );
+```
+
+The service writes a `PasswordHistory` row. The `PasswordHistoryRule` checks against the configured `history_count` previous entries.
+
+## Checking against HaveIBeenPwned without writing
+
+`HaveIBeenPwnedService` uses k-anonymity — only the first 5 chars of the SHA-1 hash leave your server.
+
+```php
+use ArtisanPackUI\SecurityAuth\Services\HaveIBeenPwnedService;
+
+$service = app( HaveIBeenPwnedService::class );
+$compromisedCount = $service->check( $password );   // 0 = not seen, >0 = times seen in breaches
+if ( $service->isCompromised( $password ) ) {
+    // refuse
+}
+```
+
+## Expiration
+
+`PasswordSecurityService::isExpired($user)` and `daysUntilExpiration($user)` check against the configured `expire_after_days`. Combine with the `password.policy` middleware to force a reset when expired:
+
+```php
+Route::middleware(['auth', 'password.policy'])->group(function (): void {
+    // Routes here redirect to a "change your password" flow when
+    // the user's password is expired or doesn't meet current policy.
+});
+```
+
+## Disabling individual checks
+
+Configure thresholds to 0 / false to disable a specific check:
+
+```php
+'password_security' => [
+    'breach_check'      => false,   // skip HIBP
+    'history_count'     => 0,       // allow reuse
+    'expire_after_days' => 0,       // never expire
+],
+```
+
+Even with checks disabled the rules don't throw — they simply pass.

--- a/docs/usage/session-management.md
+++ b/docs/usage/session-management.md
@@ -33,7 +33,7 @@ $result = $sessionManager->validateSessionBindings( $session, $request );
 if ( ! $result['valid'] ) {
     // IP or UA changed — terminate the session
     auth()->logout();
-    redirect()->route('login')->with('error', 'Session invalidated for security.');
+    return redirect()->route('login')->with('error', 'Session invalidated for security.');
 }
 ```
 

--- a/docs/usage/session-management.md
+++ b/docs/usage/session-management.md
@@ -1,0 +1,96 @@
+---
+title: Session Management
+---
+
+# Session Management
+
+`AdvancedSessionManager` (bound to `SessionSecurityInterface`) layers session security features on top of Laravel's standard session handling.
+
+## Recording a session at login
+
+```php
+use ArtisanPackUI\SecurityAuth\Authentication\Contracts\SessionSecurityInterface;
+
+$sessionManager = app( SessionSecurityInterface::class );
+
+$session = $sessionManager->createSession(
+    user: $user,
+    request: $request,
+    authMethod: 'password',          // password | 2fa | webauthn | sso etc.
+    metadata: ['location' => $city],
+);
+```
+
+Writes a `UserSession` row tied to the current Laravel session ID. The row carries the IP, UA, auth method, and metadata.
+
+## Validating bindings on each request
+
+When `bind_to_ip` or `bind_to_user_agent` is on, run validation on every request (e.g. via your own middleware):
+
+```php
+$result = $sessionManager->validateSessionBindings( $session, $request );
+
+if ( ! $result['valid'] ) {
+    // IP or UA changed — terminate the session
+    auth()->logout();
+    redirect()->route('login')->with('error', 'Session invalidated for security.');
+}
+```
+
+## Touching the session
+
+Updates `last_activity_at` so the dashboard shows accurate "last active" data:
+
+```php
+$sessionManager->touchSession( $session );
+```
+
+Wire this into a middleware so it fires on every request, or call manually from significant events.
+
+## Terminating
+
+```php
+$sessionManager->terminateSession( $sessionId );           // one
+$sessionManager->terminateOtherSessions( $user, $currentSessionId );  // all except current
+$sessionManager->terminateAllSessions( $user );            // sign out everywhere
+```
+
+`terminateSession` removes both the `UserSession` row and invalidates the Laravel session cookie / token via the session store.
+
+## Listing the user's sessions
+
+```php
+$sessions = $sessionManager->getUserSessions( $user );   // Collection<UserSession>
+```
+
+The `SessionManager` Livewire component renders this list with terminate controls.
+
+## Rotation
+
+`rotateSession` generates a new session ID for the current session while preserving the user's auth state. Use after privilege changes (role grant, password change, etc.):
+
+```php
+$rotatedSession = $sessionManager->rotateSession( $session );
+```
+
+`session.rotate_on_privilege_change` config flag (default true) makes the session rotation happen automatically when the package detects privilege changes via events.
+
+## Concurrent session limits
+
+```php
+'sessions' => [
+    'max_concurrent' => 5,  // 0 = unlimited
+],
+```
+
+When set, creating a new session past the limit terminates the oldest one first. Useful for shared accounts or to enforce "one device per user" policies.
+
+## Idle timeout
+
+```php
+'sessions' => [
+    'idle_timeout_minutes' => 60,
+],
+```
+
+Sessions inactive longer than `idle_timeout_minutes` are terminated automatically the next time they're touched. The user is logged out cleanly.

--- a/docs/usage/step-up.md
+++ b/docs/usage/step-up.md
@@ -1,0 +1,75 @@
+---
+title: Step-Up Authentication
+---
+
+# Step-Up Authentication
+
+Forces a fresh credential challenge before access to sensitive operations — even for already-authenticated users. Common pattern: require re-confirmation before changing email, deleting account, viewing financial detail, etc.
+
+## How it works
+
+1. User is already signed in.
+2. Request hits a route protected by `step-up` middleware.
+3. Middleware checks `session()->get('step_up_verified_at')` against `freshness_minutes` config.
+4. If stale or missing, middleware redirects to a challenge page (or returns 403 for API requests).
+5. Challenge page mounts `StepUpAuthenticationModal` Livewire component.
+6. User verifies via available method (password, 2FA, WebAuthn).
+7. Component writes a fresh `step_up_verified_at` timestamp to session.
+8. User is redirected back to the original route.
+
+## Apply the middleware
+
+```php
+Route::middleware('step-up')->group(function (): void {
+    Route::delete('/account', [AccountController::class, 'destroy']);
+    Route::put('/email', [EmailController::class, 'update']);
+    Route::get('/api-tokens', [ApiTokenController::class, 'index']);
+});
+```
+
+## Tuning freshness
+
+```php
+'step_up' => [
+    'freshness_minutes' => 15,
+    'available_methods' => ['password', '2fa', 'webauthn'],
+],
+```
+
+- Lower freshness = more re-challenges = more security, more friction.
+- Restrict `available_methods` per app needs — e.g. drop `'password'` if you require 2FA for step-up.
+
+## Triggering programmatically
+
+Outside of the middleware path, force a step-up check inline:
+
+```php
+if ( session()->get('step_up_verified_at') < now()->subMinutes(15) ) {
+    return redirect()->route('step-up.challenge', ['back' => url()->current()]);
+}
+```
+
+## Using the Livewire modal
+
+```blade
+<livewire:step-up-authentication-modal />
+```
+
+Open it from JS / Alpine:
+
+```html
+<button @click="$wire.dispatch('open-step-up', { redirectUrl: '/account' })">
+    Delete account
+</button>
+```
+
+The modal:
+- Lists available methods (password / 2FA / WebAuthn etc.) based on what the user has set up
+- Verifies the credential against the same logic as login
+- On success: writes `step_up_verified_at`, dispatches `step-up-verified` event, navigates to `redirectUrl` if supplied
+
+## When to skip step-up
+
+- Read-only sensitive views — depends on threat model. Skip if you don't want the friction; require if data exfiltration matters.
+- API endpoints called by your own JS that already has fresh auth — skip; step-up is a UX pattern, less applicable headless.
+- Already-elevated sessions (within freshness window) — middleware handles this automatically.

--- a/docs/usage/two-factor.md
+++ b/docs/usage/two-factor.md
@@ -22,7 +22,7 @@ class User extends Authenticatable
 }
 ```
 
-This adds three columns (via migration) and three methods:
+This adds three columns (via migration) and four methods:
 - `getTwoFactorEnabledAttribute(): bool`
 - `hasTwoFactorEnabled(): bool`
 - `generateTwoFactorSecret(): void`

--- a/docs/usage/two-factor.md
+++ b/docs/usage/two-factor.md
@@ -1,0 +1,88 @@
+---
+title: Two-Factor Authentication
+---
+
+# Two-Factor Authentication
+
+`TwoFactorManager` (resolved via the `TwoFactor` Facade) supports two providers out of the box:
+
+- `EmailProvider` — emails a numeric code; simpler deploy, less secure
+- `Google2faProvider` — TOTP via `pragmarx/google2fa`; better security, requires authenticator app
+
+Pick the default via `config('artisanpack.security-auth.two_factor.default_provider')`. Switch per-call to use the other.
+
+## Enable on a User model
+
+```php
+use ArtisanPackUI\SecurityAuth\TwoFactor\TwoFactorAuthenticatable;
+
+class User extends Authenticatable
+{
+    use TwoFactorAuthenticatable;
+}
+```
+
+This adds three columns (via migration) and three methods:
+- `getTwoFactorEnabledAttribute(): bool`
+- `hasTwoFactorEnabled(): bool`
+- `generateTwoFactorSecret(): void`
+- `generateRecoveryCodes(): void`
+
+## Generating secrets and recovery codes
+
+```php
+$user->generateTwoFactorSecret();        // writes encrypted secret to two_factor_secret column
+$user->generateRecoveryCodes();          // writes encrypted JSON array of codes
+$user->two_factor_enabled_at = now();
+$user->save();
+```
+
+Recovery codes display once — the user must store them somewhere safe. Re-generating invalidates all prior codes.
+
+## Sending a challenge
+
+```php
+use ArtisanPackUI\SecurityAuth\Facades\TwoFactor;
+
+TwoFactor::sendChallenge( $user );
+// For email provider: emails a code (lifetime configurable)
+// For TOTP: no-op — user reads their authenticator app
+```
+
+## Verifying
+
+```php
+if ( TwoFactor::verify( $user, $request->input('code') ) ) {
+    // valid — complete login or step-up
+    session()->put('two_factor_verified_at', now());
+}
+```
+
+`verify()` accepts both:
+- The current time-window code (email or TOTP)
+- One of the user's recovery codes (consumed on use — single-use)
+
+## Using a specific provider for one call
+
+```php
+TwoFactor::provider('google2fa')->verify( $user, $code );
+```
+
+## TOTP setup (Google Authenticator etc.)
+
+```php
+$secret = $user->two_factor_secret;
+$qrCode = TwoFactor::provider('google2fa')->generateQrCode( $user );
+// Display $qrCode to the user — they scan with their authenticator app
+```
+
+## Disabling 2FA
+
+```php
+$user->two_factor_secret = null;
+$user->two_factor_recovery_codes = null;
+$user->two_factor_enabled_at = null;
+$user->save();
+```
+
+The trait doesn't provide a `disableTwoFactor()` helper because most apps need to gate this behind extra verification (re-confirm password, send confirmation email, etc.) — do that yourself.

--- a/resources/views/livewire/account-lockout-status.blade.php
+++ b/resources/views/livewire/account-lockout-status.blade.php
@@ -1,0 +1,82 @@
+{{--
+    Account lockout status banner.
+
+    Plain HTML + Tailwind by design — this package does not depend on
+    artisanpack-ui/livewire-ui-components.
+
+    Renders the current lockout banner (when applicable) and a paginated
+    history of past lockouts for the authenticated user.
+--}}
+<div class="space-y-4">
+    @if ( $currentLockout )
+        {{-- Active lockout banner --}}
+        <div role="alert" class="bg-red-50 border-l-4 border-red-500 p-4 rounded">
+            <div class="flex items-start gap-3">
+                <span class="text-red-500 text-xl" aria-hidden="true">⚠️</span>
+                <div class="flex-1">
+                    <h3 class="text-red-800 font-semibold">{{ __( 'Account locked' ) }}</h3>
+                    <p class="text-red-700 text-sm mt-1">
+                        {{ __( 'Reason' ) }}: {{ $currentLockout['reason'] ?? __( 'Security policy' ) }}
+                    </p>
+                    @if ( isset( $currentLockout['unlocks_at'] ) )
+                        <p class="text-red-600 text-xs mt-1">
+                            {{ __( 'Unlocks' ) }}: {{ $currentLockout['unlocks_at'] }}
+                        </p>
+                    @endif
+                </div>
+            </div>
+        </div>
+    @else
+        <div role="status" class="bg-green-50 border-l-4 border-green-500 p-3 rounded">
+            <div class="flex items-center gap-2">
+                <span class="text-green-600" aria-hidden="true">✓</span>
+                <span class="text-green-800 text-sm">{{ __( 'Your account is not locked.' ) }}</span>
+            </div>
+        </div>
+    @endif
+
+    {{-- Lockout history --}}
+    <div>
+        <h3 class="text-base font-semibold mb-2">{{ __( 'Recent lockout history' ) }}</h3>
+        @if ( $this->lockoutHistory->isEmpty() )
+            <p class="text-sm text-gray-500">{{ __( 'No previous lockouts.' ) }}</p>
+        @else
+            <table class="w-full text-sm">
+                <thead>
+                    <tr class="border-b">
+                        <th class="text-left px-3 py-2 font-semibold text-gray-700">{{ __( 'When' ) }}</th>
+                        <th class="text-left px-3 py-2 font-semibold text-gray-700">{{ __( 'Reason' ) }}</th>
+                        <th class="text-left px-3 py-2 font-semibold text-gray-700">{{ __( 'Duration' ) }}</th>
+                        <th class="text-left px-3 py-2 font-semibold text-gray-700">{{ __( 'Status' ) }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ( $this->lockoutHistory as $lockout )
+                        <tr wire:key="lockout-{{ $lockout->id }}" class="border-b hover:bg-gray-50">
+                            <td class="px-3 py-2">{{ $lockout->created_at?->diffForHumans() }}</td>
+                            <td class="px-3 py-2">{{ $lockout->reason ?? __( '—' ) }}</td>
+                            <td class="px-3 py-2">
+                                @if ( $lockout->duration_minutes )
+                                    {{ $lockout->duration_minutes }} {{ __( 'minutes' ) }}
+                                @else
+                                    {{ __( '—' ) }}
+                                @endif
+                            </td>
+                            <td class="px-3 py-2">
+                                @if ( $lockout->is_active ?? false )
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800">{{ __( 'Active' ) }}</span>
+                                @else
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800">{{ __( 'Cleared' ) }}</span>
+                                @endif
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+
+            <div class="mt-3">
+                {{ $this->lockoutHistory->links() }}
+            </div>
+        @endif
+    </div>
+</div>

--- a/resources/views/livewire/password-strength-meter.blade.php
+++ b/resources/views/livewire/password-strength-meter.blade.php
@@ -1,0 +1,66 @@
+{{--
+    Password strength meter.
+
+    Plain HTML + Tailwind by design — this package does not depend on
+    artisanpack-ui/livewire-ui-components. Override this view in your app
+    if you want richer UI components.
+
+    The host form is expected to wire its own password input to the
+    component's `wire:model="password"` — see usage examples in the docs.
+--}}
+<div class="space-y-2" role="status" aria-live="polite">
+    @if ( $password !== '' )
+        {{-- Visual strength bar --}}
+        <div class="w-full bg-gray-200 rounded-full h-2">
+            <div
+                class="h-2 rounded-full transition-all duration-300 {{ match( $this->getProgressColor() ) {
+                    'red'    => 'bg-red-500',
+                    'orange' => 'bg-orange-500',
+                    'yellow' => 'bg-yellow-500',
+                    'green'  => 'bg-green-500',
+                    default  => 'bg-gray-400',
+                } }}"
+                style="width: {{ $this->getBarWidth() }}%"
+            ></div>
+        </div>
+
+        {{-- Label + crack time --}}
+        <div class="flex items-center justify-between text-sm">
+            <span class="font-medium inline-flex items-center px-2 py-0.5 rounded {{ match( $this->getBadgeColor() ) {
+                'red'    => 'bg-red-100 text-red-800',
+                'orange' => 'bg-orange-100 text-orange-800',
+                'yellow' => 'bg-yellow-100 text-yellow-800',
+                'green'  => 'bg-green-100 text-green-800',
+                default  => 'bg-gray-100 text-gray-800',
+            } }}">
+                {{ $label }}
+            </span>
+            @if ( $crackTime )
+                <span class="text-xs text-gray-500">
+                    {{ __( 'Estimated crack time' ) }}: {{ $crackTime }}
+                </span>
+            @endif
+        </div>
+
+        {{-- Feedback messages --}}
+        @if ( ! empty( $feedback ) )
+            <ul class="text-xs text-gray-600 space-y-0.5 list-disc list-inside">
+                @foreach ( $feedback as $message )
+                    <li>{{ $message }}</li>
+                @endforeach
+            </ul>
+        @endif
+
+        {{-- Requirements checklist --}}
+        @if ( ! empty( $requirements ) )
+            <ul class="text-xs space-y-0.5">
+                @foreach ( $requirements as $requirement )
+                    <li class="flex items-center gap-1 {{ ( $requirement['met'] ?? false ) ? 'text-green-700' : 'text-gray-500' }}">
+                        <span aria-hidden="true">{{ ( $requirement['met'] ?? false ) ? '✓' : '○' }}</span>
+                        <span>{{ $requirement['label'] ?? $requirement['rule'] ?? '' }}</span>
+                    </li>
+                @endforeach
+            </ul>
+        @endif
+    @endif
+</div>

--- a/resources/views/livewire/password-strength-meter.blade.php
+++ b/resources/views/livewire/password-strength-meter.blade.php
@@ -9,7 +9,7 @@
     component's `wire:model="password"` — see usage examples in the docs.
 --}}
 <div class="space-y-2" role="status" aria-live="polite">
-    @if ( $password !== '' )
+    @if ( filled( $password ) )
         {{-- Visual strength bar --}}
         <div class="w-full bg-gray-200 rounded-full h-2">
             <div

--- a/resources/views/livewire/session-manager.blade.php
+++ b/resources/views/livewire/session-manager.blade.php
@@ -76,7 +76,7 @@
                                 <div class="flex gap-2">
                                     <button
                                         type="button"
-                                        wire:click="terminateSession('{{ $session['id'] }}')"
+                                        wire:click="terminateSession({{ json_encode($session['id']) }})"
                                         class="text-xs px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded font-medium"
                                     >
                                         {{ __( 'Confirm sign out' ) }}
@@ -92,7 +92,7 @@
                             @else
                                 <button
                                     type="button"
-                                    wire:click="confirmTerminate('{{ $session['id'] }}')"
+                                    wire:click="confirmTerminate({{ json_encode($session['id']) }})"
                                     class="text-sm text-red-600 hover:text-red-800 font-medium"
                                     aria-label="{{ $isCurrent ? __( 'Sign out of this current session' ) : __( 'Sign out of this session' ) }}"
                                 >

--- a/resources/views/livewire/session-manager.blade.php
+++ b/resources/views/livewire/session-manager.blade.php
@@ -1,0 +1,109 @@
+{{--
+    Session manager — lists active sessions and offers terminate controls.
+
+    Plain HTML + Tailwind by design — this package does not depend on
+    artisanpack-ui/livewire-ui-components.
+--}}
+<div class="space-y-4">
+    <div class="flex justify-between items-center">
+        <h2 class="text-xl font-bold">{{ __( 'Active sessions' ) }}</h2>
+        @if ( count( $sessions ) > 1 )
+            <button
+                type="button"
+                wire:click="terminateAllOtherSessions"
+                wire:confirm="{{ __( 'Sign out of all other sessions?' ) }}"
+                class="text-sm text-red-600 hover:text-red-800 font-medium"
+            >
+                {{ __( 'Sign out of all other sessions' ) }}
+            </button>
+        @endif
+    </div>
+
+    @if ( empty( $sessions ) )
+        <p class="text-sm text-gray-500">{{ __( 'No active sessions.' ) }}</p>
+    @else
+        <div class="space-y-2">
+            @foreach ( $sessions as $session )
+                @php
+                    $isCurrent = ( $session['id'] ?? null ) === $currentSessionId;
+                    $isTerminating = ( $session['id'] ?? null ) === $terminatingSessionId;
+                @endphp
+                <div
+                    wire:key="session-{{ $session['id'] }}"
+                    class="border rounded-lg p-4 {{ $isCurrent ? 'bg-blue-50 border-blue-200' : 'bg-white border-gray-200' }}"
+                >
+                    <div class="flex items-start justify-between gap-4">
+                        <div class="flex-1 space-y-1">
+                            <div class="flex items-center gap-2">
+                                <span class="font-medium">
+                                    {{ $session['device'] ?? __( 'Unknown device' ) }}
+                                </span>
+                                @if ( $isCurrent )
+                                    <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                                        {{ __( 'This session' ) }}
+                                    </span>
+                                @endif
+                            </div>
+                            <div class="text-sm text-gray-600 space-y-0.5">
+                                @if ( isset( $session['ip_address'] ) )
+                                    <div>
+                                        <span class="font-medium">{{ __( 'IP' ) }}:</span>
+                                        <span class="font-mono">{{ $session['ip_address'] }}</span>
+                                    </div>
+                                @endif
+                                @if ( isset( $session['location'] ) )
+                                    <div>
+                                        <span class="font-medium">{{ __( 'Location' ) }}:</span>
+                                        {{ $session['location'] }}
+                                    </div>
+                                @endif
+                                @if ( isset( $session['last_activity'] ) )
+                                    <div>
+                                        <span class="font-medium">{{ __( 'Last active' ) }}:</span>
+                                        {{ $session['last_activity'] }}
+                                    </div>
+                                @endif
+                                @if ( isset( $session['auth_method'] ) )
+                                    <div class="text-xs text-gray-500">
+                                        {{ __( 'Signed in via' ) }}: {{ $session['auth_method'] }}
+                                    </div>
+                                @endif
+                            </div>
+                        </div>
+
+                        @if ( ! $isCurrent )
+                            <div>
+                                @if ( $isTerminating )
+                                    <div class="flex gap-2">
+                                        <button
+                                            type="button"
+                                            wire:click="terminateSession('{{ $session['id'] }}')"
+                                            class="text-xs px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded font-medium"
+                                        >
+                                            {{ __( 'Confirm sign out' ) }}
+                                        </button>
+                                        <button
+                                            type="button"
+                                            wire:click="cancelTerminate"
+                                            class="text-xs px-3 py-1.5 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 rounded font-medium"
+                                        >
+                                            {{ __( 'Cancel' ) }}
+                                        </button>
+                                    </div>
+                                @else
+                                    <button
+                                        type="button"
+                                        wire:click="confirmTerminate('{{ $session['id'] }}')"
+                                        class="text-sm text-red-600 hover:text-red-800 font-medium"
+                                    >
+                                        {{ __( 'Sign out' ) }}
+                                    </button>
+                                @endif
+                            </div>
+                        @endif
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/session-manager.blade.php
+++ b/resources/views/livewire/session-manager.blade.php
@@ -71,36 +71,35 @@
                             </div>
                         </div>
 
-                        @if ( ! $isCurrent )
-                            <div>
-                                @if ( $isTerminating )
-                                    <div class="flex gap-2">
-                                        <button
-                                            type="button"
-                                            wire:click="terminateSession('{{ $session['id'] }}')"
-                                            class="text-xs px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded font-medium"
-                                        >
-                                            {{ __( 'Confirm sign out' ) }}
-                                        </button>
-                                        <button
-                                            type="button"
-                                            wire:click="cancelTerminate"
-                                            class="text-xs px-3 py-1.5 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 rounded font-medium"
-                                        >
-                                            {{ __( 'Cancel' ) }}
-                                        </button>
-                                    </div>
-                                @else
+                        <div>
+                            @if ( $isTerminating )
+                                <div class="flex gap-2">
                                     <button
                                         type="button"
-                                        wire:click="confirmTerminate('{{ $session['id'] }}')"
-                                        class="text-sm text-red-600 hover:text-red-800 font-medium"
+                                        wire:click="terminateSession('{{ $session['id'] }}')"
+                                        class="text-xs px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded font-medium"
                                     >
-                                        {{ __( 'Sign out' ) }}
+                                        {{ __( 'Confirm sign out' ) }}
                                     </button>
-                                @endif
-                            </div>
-                        @endif
+                                    <button
+                                        type="button"
+                                        wire:click="cancelTerminate"
+                                        class="text-xs px-3 py-1.5 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 rounded font-medium"
+                                    >
+                                        {{ __( 'Cancel' ) }}
+                                    </button>
+                                </div>
+                            @else
+                                <button
+                                    type="button"
+                                    wire:click="confirmTerminate('{{ $session['id'] }}')"
+                                    class="text-sm text-red-600 hover:text-red-800 font-medium"
+                                    aria-label="{{ $isCurrent ? __( 'Sign out of this current session' ) : __( 'Sign out of this session' ) }}"
+                                >
+                                    {{ $isCurrent ? __( 'Sign out this session' ) : __( 'Sign out' ) }}
+                                </button>
+                            @endif
+                        </div>
                     </div>
                 </div>
             @endforeach

--- a/resources/views/livewire/step-up-authentication-modal.blade.php
+++ b/resources/views/livewire/step-up-authentication-modal.blade.php
@@ -1,0 +1,137 @@
+{{--
+    Step-up authentication modal.
+
+    Plain HTML + Tailwind by design — this package does not depend on
+    artisanpack-ui/livewire-ui-components.
+
+    Renders only when $show is true. The host app dispatches `open-step-up`
+    (with optional redirect URL) to open it, or calls `openModal()` directly.
+--}}
+<div>
+    @if ( $show )
+        <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="step-up-title"
+            class="fixed inset-0 z-50 overflow-y-auto"
+        >
+            {{-- Backdrop --}}
+            <div class="fixed inset-0 bg-black bg-opacity-50 transition-opacity" aria-hidden="true"></div>
+
+            {{-- Modal panel --}}
+            <div class="flex min-h-full items-center justify-center p-4">
+                <div class="relative bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+                    {{-- Header --}}
+                    <div class="flex justify-between items-start mb-4">
+                        <h2 id="step-up-title" class="text-lg font-bold">
+                            {{ __( 'Confirm your identity' ) }}
+                        </h2>
+                        <button
+                            type="button"
+                            wire:click="closeModal"
+                            class="text-gray-400 hover:text-gray-600"
+                            aria-label="{{ __( 'Close' ) }}"
+                        >
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+
+                    <p class="text-sm text-gray-600 mb-4">
+                        {{ __( 'For your security, please verify your identity to continue.' ) }}
+                    </p>
+
+                    {{-- Method selector --}}
+                    @if ( count( $availableMethods ) > 1 )
+                        <div class="mb-4">
+                            <label for="step-up-method" class="block text-sm font-medium text-gray-700 mb-1">
+                                {{ __( 'Verification method' ) }}
+                            </label>
+                            <select
+                                id="step-up-method"
+                                wire:model.live="method"
+                                class="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                            >
+                                @foreach ( $availableMethods as $availableMethod )
+                                    <option value="{{ $availableMethod }}">{{ $this->getMethodLabel( $availableMethod ) }}</option>
+                                @endforeach
+                            </select>
+                        </div>
+                    @endif
+
+                    {{-- Error --}}
+                    @if ( $error )
+                        <div role="alert" class="bg-red-50 border border-red-200 text-red-700 text-sm rounded p-3 mb-4">
+                            {{ $error }}
+                        </div>
+                    @endif
+
+                    {{-- Method-specific form --}}
+                    @if ( $method === 'password' )
+                        <form wire:submit.prevent="verifyPassword">
+                            <label for="step-up-password" class="block text-sm font-medium text-gray-700 mb-1">
+                                {{ __( 'Password' ) }}
+                            </label>
+                            <input
+                                id="step-up-password"
+                                type="password"
+                                wire:model="password"
+                                autocomplete="current-password"
+                                autofocus
+                                class="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm"
+                            />
+                            <div class="mt-4 flex justify-end gap-2">
+                                <button
+                                    type="button"
+                                    wire:click="closeModal"
+                                    class="px-4 py-2 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 text-sm font-medium rounded-md"
+                                >
+                                    {{ __( 'Cancel' ) }}
+                                </button>
+                                <button
+                                    type="submit"
+                                    class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-md"
+                                >
+                                    {{ __( 'Verify' ) }}
+                                </button>
+                            </div>
+                        </form>
+                    @elseif ( $method === '2fa' )
+                        <form wire:submit.prevent="verify2fa">
+                            <label for="step-up-code" class="block text-sm font-medium text-gray-700 mb-1">
+                                {{ __( 'Two-factor code' ) }}
+                            </label>
+                            <input
+                                id="step-up-code"
+                                type="text"
+                                wire:model="code"
+                                inputmode="numeric"
+                                autocomplete="one-time-code"
+                                pattern="[0-9]*"
+                                autofocus
+                                class="block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 sm:text-sm tracking-widest text-center"
+                            />
+                            <div class="mt-4 flex justify-end gap-2">
+                                <button type="button" wire:click="closeModal" class="px-4 py-2 bg-white hover:bg-gray-50 text-gray-700 border border-gray-300 text-sm font-medium rounded-md">
+                                    {{ __( 'Cancel' ) }}
+                                </button>
+                                <button type="submit" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium rounded-md">
+                                    {{ __( 'Verify' ) }}
+                                </button>
+                            </div>
+                        </form>
+                    @else
+                        {{-- WebAuthn / biometric — JS-driven, host app supplies the credential and dispatches verifyWebAuthn / verifyBiometric --}}
+                        <div class="text-center py-6">
+                            <p class="text-sm text-gray-600 mb-4">
+                                {{ __( 'Please use your authenticator to verify.' ) }}
+                            </p>
+                            <div class="text-xs text-gray-500">
+                                {{ __( 'Awaiting authenticator response…' ) }}
+                            </div>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    @endif
+</div>

--- a/src/Authentication/Contracts/AccountLockoutInterface.php
+++ b/src/Authentication/Contracts/AccountLockoutInterface.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * AccountLockoutInterface contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Authentication\Contracts;

--- a/src/Authentication/Contracts/SessionSecurityInterface.php
+++ b/src/Authentication/Contracts/SessionSecurityInterface.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SessionSecurityInterface contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Authentication\Contracts;

--- a/src/Authentication/Lockout/AccountLockoutManager.php
+++ b/src/Authentication/Lockout/AccountLockoutManager.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * AccountLockoutManager account lockout class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Authentication\Lockout;

--- a/src/Authentication/Session/AdvancedSessionManager.php
+++ b/src/Authentication/Session/AdvancedSessionManager.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * AdvancedSessionManager session management class.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Authentication\Session;

--- a/src/Console/Commands/ManageAccountLockout.php
+++ b/src/Console/Commands/ManageAccountLockout.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * `ManageAccountLockout` Artisan command.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Console\Commands;

--- a/src/Contracts/BreachCheckerInterface.php
+++ b/src/Contracts/BreachCheckerInterface.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * BreachCheckerInterface contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Contracts;

--- a/src/Contracts/PasswordSecurityServiceInterface.php
+++ b/src/Contracts/PasswordSecurityServiceInterface.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * PasswordSecurityServiceInterface contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Contracts;

--- a/src/Events/AccountLocked.php
+++ b/src/Events/AccountLocked.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * AccountLocked event.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Events;

--- a/src/Http/Middleware/CheckAccountLockout.php
+++ b/src/Http/Middleware/CheckAccountLockout.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * CheckAccountLockout route middleware.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Http\Middleware;

--- a/src/Http/Middleware/EnforcePasswordPolicy.php
+++ b/src/Http/Middleware/EnforcePasswordPolicy.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * EnforcePasswordPolicy route middleware.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Http\Middleware;

--- a/src/Http/Middleware/StepUpAuthentication.php
+++ b/src/Http/Middleware/StepUpAuthentication.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * StepUpAuthentication route middleware.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Http\Middleware;

--- a/src/Livewire/AccountLockoutStatus.php
+++ b/src/Livewire/AccountLockoutStatus.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * AccountLockoutStatus Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Livewire;

--- a/src/Livewire/PasswordStrengthMeter.php
+++ b/src/Livewire/PasswordStrengthMeter.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * PasswordStrengthMeter Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Livewire;

--- a/src/Livewire/SessionManager.php
+++ b/src/Livewire/SessionManager.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * SessionManager Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Livewire;

--- a/src/Livewire/StepUpAuthenticationModal.php
+++ b/src/Livewire/StepUpAuthenticationModal.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * StepUpAuthenticationModal Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Livewire;

--- a/src/Models/AccountLockout.php
+++ b/src/Models/AccountLockout.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * AccountLockout Eloquent model.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Models;

--- a/src/Models/PasswordHistory.php
+++ b/src/Models/PasswordHistory.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * PasswordHistory Eloquent model.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Models;

--- a/src/Models/UserSession.php
+++ b/src/Models/UserSession.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * UserSession Eloquent model.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Models;

--- a/src/Rules/NotCompromised.php
+++ b/src/Rules/NotCompromised.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * NotCompromised validation rule.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Rules;

--- a/src/Rules/PasswordComplexity.php
+++ b/src/Rules/PasswordComplexity.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * PasswordComplexity validation rule.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Rules;

--- a/src/Rules/PasswordHistoryRule.php
+++ b/src/Rules/PasswordHistoryRule.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * PasswordHistoryRule validation rule.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Rules;

--- a/src/Rules/PasswordPolicy.php
+++ b/src/Rules/PasswordPolicy.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * PasswordPolicy validation rule.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Rules;

--- a/src/SecurityAuthServiceProvider.php
+++ b/src/SecurityAuthServiceProvider.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * Security Auth service provider.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth;

--- a/src/Services/HaveIBeenPwnedService.php
+++ b/src/Services/HaveIBeenPwnedService.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * HaveIBeenPwnedService service.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Services;

--- a/src/Services/PasswordSecurityService.php
+++ b/src/Services/PasswordSecurityService.php
@@ -1,5 +1,16 @@
 <?php
 
+/**
+ * PasswordSecurityService service.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage SecurityAuth
+ *
+ * @author     Jacob Martella <support@artisanpackui.dev>
+ *
+ * @since      1.0.0
+ */
+
 declare( strict_types=1 );
 
 namespace ArtisanPackUI\SecurityAuth\Services;

--- a/tests/Feature/Livewire/ComponentRenderTest.php
+++ b/tests/Feature/Livewire/ComponentRenderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\SecurityAuth\Livewire\AccountLockoutStatus;
+use ArtisanPackUI\SecurityAuth\Livewire\PasswordStrengthMeter;
+use ArtisanPackUI\SecurityAuth\Livewire\SessionManager;
+use ArtisanPackUI\SecurityAuth\Livewire\StepUpAuthenticationModal;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Livewire\Livewire;
+
+beforeEach( function (): void {
+    // The package migrations alter a `users` table that doesn't exist in
+    // the testbench by default. Stand up a minimal one before the package
+    // migrations run.
+    if ( ! Schema::hasTable( 'users' ) ) {
+        Schema::create( 'users', function ( Blueprint $table ): void {
+            $table->id();
+            $table->string( 'name' );
+            $table->string( 'email' )->unique();
+            $table->timestamp( 'email_verified_at' )->nullable();
+            $table->string( 'password' );
+            $table->rememberToken();
+            $table->timestamps();
+        } );
+    }
+
+    $this->artisan( 'migrate' );
+
+    $this->actingAs( new class extends Illuminate\Foundation\Auth\User {
+        public $id = 1;
+
+        protected $guarded = [];
+
+        public function getAuthIdentifier()
+        {
+            return 1;
+        }
+    } );
+} );
+
+it( 'renders the PasswordStrengthMeter Livewire component', function (): void {
+    Livewire::test( PasswordStrengthMeter::class )
+        ->assertStatus( 200 );
+} );
+
+it( 'renders the AccountLockoutStatus Livewire component', function (): void {
+    Livewire::test( AccountLockoutStatus::class )
+        ->assertStatus( 200 );
+} );
+
+it( 'renders the SessionManager Livewire component', function (): void {
+    Livewire::test( SessionManager::class )
+        ->assertStatus( 200 );
+} );
+
+it( 'renders the StepUpAuthenticationModal Livewire component', function (): void {
+    Livewire::test( StepUpAuthenticationModal::class )
+        ->assertStatus( 200 );
+} );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ declare( strict_types=1 );
 namespace Tests;
 
 use ArtisanPackUI\SecurityAuth\SecurityAuthServiceProvider;
+use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
 /**
@@ -36,6 +37,7 @@ abstract class TestCase extends BaseTestCase
     protected function getPackageProviders( $app ): array
     {
         return [
+            LivewireServiceProvider::class,
             SecurityAuthServiceProvider::class,
         ];
     }

--- a/tests/Unit/NotCompromisedTest.php
+++ b/tests/Unit/NotCompromisedTest.php
@@ -92,8 +92,8 @@ class NotCompromisedTest extends TestCase
     {
         $mock = $this->createMock( BreachCheckerInterface::class );
         $mock->method( 'check' )->willReturn( $occurrences );
-        $mock->method( 'isCompromised' )->willReturn( $occurrences > 0);
+        $mock->method( 'isCompromised' )->willReturn( $occurrences > 0 );
 
-        $this->app->instance( BreachCheckerInterface::class, $mock);
+        $this->app->instance( BreachCheckerInterface::class, $mock );
     }
 }

--- a/tests/Unit/PasswordComplexityTest.php
+++ b/tests/Unit/PasswordComplexityTest.php
@@ -226,8 +226,8 @@ class PasswordComplexityTest extends TestCase
     {
         $rule = new PasswordComplexity();
 
-        $this->assertValidates( $rule, 'MyStr0ng!P@ssword');
-        $this->assertValidates( $rule, 'C0mplex#Pass917');
-        $this->assertValidates( $rule, 'Secur3&Unique99');
+        $this->assertValidates( $rule, 'MyStr0ng!P@ssword' );
+        $this->assertValidates( $rule, 'C0mplex#Pass917' );
+        $this->assertValidates( $rule, 'Secur3&Unique99' );
     }
 }


### PR DESCRIPTION
## Summary

Closes #11.

Brings the package up to the ArtisanPack UI ecosystem release standard (composer.json, LICENSE, README, CHANGELOG, CONTRIBUTING, docs/, PHPDoc, lint, tests) and bumps the version to 1.0.0. Wave 2 unblocking work shipped the 4 missing Livewire Blade views (password-strength-meter, account-lockout-status, session-manager, step-up-authentication-modal) in plain HTML + Tailwind.

See the commit body for the per-phase detail.

## Test plan

- [x] composer validate clean
- [x] composer lint clean
- [x] composer test all-green (28 passed, 49 assertions)
- [ ] CodeRabbit auto-review on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Livewire UI: password strength meter, account lockout status, session manager, and step‑up authentication modal
  * Automated workflows: improved CI (lint + matrix tests), release-on-tag pipeline, auto-milestone, and optional AI code-review integrations

* **Documentation**
  * Complete docs: getting started, installation, usage, advanced customization, FAQ, and troubleshooting

* **Chores**
  * Released v1.0.0; license changed to MIT and package metadata updated

* **Tests**
  * Added Livewire render feature tests and test environment wiring

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/security-auth/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->