### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-06-14
+
 ### Changed
 
 - Widened `illuminate/support` constraint to accept Laravel 13 (`^10.0|^11.0|^12.0|^13.0`).
 - Widened `pragmarx/google2fa-laravel` constraint to accept v3 (`^2.3|^3.0`), which is the Laravel-13-compatible line. The package's only consumer (`TwoFactorAuthenticatable::generateTwoFactorSecret`) calls `PragmaRX\Google2FA\Google2FA::generateSecretKey()` on the underlying `pragmarx/google2fa` core library, whose API is unchanged across the v2→v3 wrapper bump.
+- `SecurityAuth::version()` now reports `1.0.1` (was a stale `0.1.0` placeholder).
+- Installation requirements docs updated to list Laravel 13 and the widened google2fa-laravel constraint.
 
 ## [1.0.0] - 2026-05-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Widened `illuminate/support` constraint to accept Laravel 13 (`^10.0|^11.0|^12.0|^13.0`).
+- Widened `pragmarx/google2fa-laravel` constraint to accept v3 (`^2.3|^3.0`), which is the Laravel-13-compatible line. The package's only consumer (`TwoFactorAuthenticatable::generateTwoFactorSecret`) calls `PragmaRX\Google2FA\Google2FA::generateSecretKey()` on the underlying `pragmarx/google2fa` core library, whose API is unchanged across the v2→v3 wrapper bump.
+
 ## [1.0.0] - 2026-05-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ The four shipped Blade views render in plain HTML + Tailwind. Publish + override
 ## Requirements
 
 - PHP 8.2+
-- Laravel 10 / 11 / 12
-- `pragmarx/google2fa-laravel: ^2.3` (pulled in automatically) for TOTP 2FA
+- Laravel 10 / 11 / 12 / 13
+- `pragmarx/google2fa-laravel: ^2.3 | ^3.0` (pulled in automatically) for TOTP 2FA
 
 ## Sibling packages
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Authentication security for Laravel — two-factor authentication (email/TOTP), password complexity and breach checking, account lockout, and session management.",
   "type": "library",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "keywords": [
     "laravel",
     "security",

--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,9 @@
   ],
   "require": {
     "php": "^8.2",
-    "illuminate/support": "^10.0|^11.0|^12.0",
+    "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
     "artisanpack-ui/core": "^1.0",
-    "pragmarx/google2fa-laravel": "^2.3"
+    "pragmarx/google2fa-laravel": "^2.3|^3.0"
   },
   "require-dev": {
     "artisanpack-ui/code-style": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89bdb3cc1765886ae7884995721275a3",
+    "content-hash": "b9292685a0a98cfe103f3feb0fb06e72",
     "packages": [
         {
             "name": "artisanpack-ui/core",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ccfd7986a98a2869faf17f9233399c29",
+    "content-hash": "89bdb3cc1765886ae7884995721275a3",
     "packages": [
         {
             "name": "artisanpack-ui/core",
@@ -11777,5 +11777,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/docs/installation/requirements.md
+++ b/docs/installation/requirements.md
@@ -10,12 +10,12 @@ title: Requirements
 
 ## Laravel
 
-- Laravel 10 / 11 / 12
+- Laravel 10 / 11 / 12 / 13
 
 ## Composer dependencies (pulled in automatically)
 
 - `artisanpack-ui/core: ^1.0`
-- `pragmarx/google2fa-laravel: ^2.3` — backs the TOTP 2FA provider
+- `pragmarx/google2fa-laravel: ^2.3 | ^3.0` — backs the TOTP 2FA provider (v3.x is the Laravel-13-compatible line)
 
 ## Optional dependencies
 

--- a/src/SecurityAuth.php
+++ b/src/SecurityAuth.php
@@ -22,6 +22,6 @@ class SecurityAuth
 {
     public function version(): string
     {
-        return '0.1.0';
+        return '1.0.1';
     }
 }


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.0.1
- **Release Date:** 2026-06-14
- **Release Type:** Patch (compatibility)
- **Release Branch:** `release/1.0.1`
- **Target Branch:** `main`

## Release Summary

Compatibility patch that adds Laravel 13 support. Widens `illuminate/support` and `pragmarx/google2fa-laravel` constraints, fixes a stale version placeholder in `SecurityAuth::version()`, and syncs install docs.

## Changelog

### Changed

- Widened `illuminate/support` to `^10.0|^11.0|^12.0|^13.0`.
- Widened `pragmarx/google2fa-laravel` to `^2.3|^3.0`. v3 is the Laravel-13-compatible line; the package's only google2fa touchpoint (`TwoFactorAuthenticatable::generateTwoFactorSecret`) calls `PragmaRX\Google2FA\Google2FA::generateSecretKey()` on the underlying `pragmarx/google2fa` core lib (v8.x), whose API is unchanged across the v2→v3 wrapper bump.
- `SecurityAuth::version()` now reports `1.0.1` (was a stale `0.1.0` placeholder).
- Installation requirements docs (`README.md`, `docs/installation/requirements.md`) updated for Laravel 13 + widened google2fa constraint.

### Added / Deprecated / Removed / Fixed / Security

_None._

## Issues and Pull Requests

**Issues Fixed:**
- Closes #16

**Related PRs:**
- #17 (Laravel 13 support)

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

Constraints widened only — existing consumers on Laravel 10/11/12 with google2fa-laravel v2 are unaffected.

## Testing Checklist

- [x] All automated tests passing (28 tests, 49 assertions)
- [x] Manual testing completed (dev app + PR #17 review)
- [x] Security scan completed (see "Dependency Notes" below)
- [ ] Accessibility tests passing (n/a — no UI changes)
- [ ] Performance tests passing (n/a)
- [ ] Tested in staging environment
- [ ] Database migrations tested (no migration changes in this release)

## Documentation Checklist

- [x] CHANGELOG updated (`[1.0.1] - 2026-06-14` block added)
- [x] README updated (Requirements section)
- [x] API documentation updated (`docs/installation/requirements.md`)
- [ ] Migration guide written (n/a — no breaking changes)
- [x] Release notes written (this PR + CHANGELOG)

## Pre-Release Checklist

- [x] Version number updated in all necessary files (`composer.json`, `src/SecurityAuth.php`, `CHANGELOG.md`)
- [ ] Git tag prepared: `v1.0.1` (to be tagged post-merge)
- [x] Release branch created/updated: `release/1.0.1`
- [x] Dependencies updated and tested (`composer update --lock` clean; lock in sync)
- [x] Lint clean (php-cs-fixer + phpcs)

## Dependency Notes

### Outdated direct dependencies (non-blocking)

| Package | Installed | Latest | Type |
|---|---|---|---|
| `pragmarx/google2fa-laravel` | 2.3.1 | 3.0.1 | runtime — constraint now accepts v3, consumers on Laravel 13 will resolve to it |
| `artisanpack-ui/core` | 1.1.0 | 1.2.0 | runtime (minor) |
| `artisanpack-ui/code-style` | 1.1.0 | 1.1.1 | dev (patch) |
| `artisanpack-ui/code-style-pint` | 1.1.0 | 1.1.1 | dev (patch) |
| `friendsofphp/php-cs-fixer` | 3.95.1 | 3.95.7 | dev (patch) |
| `livewire/livewire` | 4.3.0 | 4.3.1 | dev (patch) |

### Security advisories (runtime, transitive only)

`composer audit --no-dev` reports 11 advisories across 8 packages — all in transitive Symfony / Guzzle / Laravel components inherited from `illuminate/support`. Severity breakdown: 1 high, 6 medium, 1 low, 3 unranked. None originate from this package's direct dependencies; consumers tracking Laravel 12.x/13.x patch releases pick up the fixes automatically.

Notable: `symfony/mime` CVE-2026-45067 (high — email header / SMTP CRLF injection), `symfony/mailer` CVE-2026-45068 (medium — argument injection in SendmailTransport).

## Post-Release Tasks

- [ ] Tag created: `v1.0.1`
- [ ] Release notes published
- [ ] Documentation deployed
- [ ] Packagist updated (auto-sync via GitHub webhook)

---

**Release Manager:** @ViewFromTheBox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 1.0.1

* **Chores**
  * Bumped version to 1.0.1.
  * Expanded Laravel version support to include Laravel 13.
  * Broadened dependency compatibility for 2FA library to accept newer versions.

* **Documentation**
  * Updated installation requirements to reflect expanded compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->